### PR TITLE
Shift speed display over when >= 100 so it doesn't overlap gauges

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -686,7 +686,15 @@ class DashFragment : Fragment() {
                 var sensingSpeedLimit = 35
                 binding.speed.scaleY = .9f
 
-                binding.speed.text = vehicleSpeedVal.toInt().toString()
+                var vehicleSpeedInt = vehicleSpeedVal.toInt()
+                var displaySpeedString = vehicleSpeedInt.toString()
+                if (vehicleSpeedInt >= 100) {
+                    // The speed display needs to be shifted slightly to the left when the value
+                    // is over 100 (either MPH or KM/h)
+
+                    displaySpeedString += " "
+                }
+                binding.speed.text = displaySpeedString
 
                 if (viewModel.getValue(Constants.uiSpeedUnits) != 0f) {
                     sensingSpeedLimit = 35f.kmh.toInt()


### PR DESCRIPTION
When the speed is 100 or greater (happens a bunch for us KM/h drivers) the speed overlaps the gauges on the right.  This code will shift the speed label over.