### PR TITLE
Change chargeStatus from PCS_hvChargeStatus to BMS_chargeRequest

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
+++ b/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
@@ -96,7 +96,7 @@ class CANSignalHelper {
         insertCANSignal(Constants.frontTemp, -1, Hex(0x396), 24, 8, 1f, -40f)
         insertCANSignal(Constants.rearTemp, -1, Hex(0x395), 24, 8, 1f, -40f)
         insertCANSignal(Constants.coolantFlow, -1, Hex(0x241), 22, 9, .1f, 0f)
-        insertCANSignal(Constants.chargeStatus, -1, Hex(0x204), 4, 2, 1f, 0f)
+        insertCANSignal(Constants.chargeStatus, -1, Hex(0x212), 29, 1, 1f, 0f)
         insertCANSignal(Constants.brakeTempFL, -1, Hex(0x3FE), 0, 10, 1f, -40f)
         insertCANSignal(Constants.brakeTempFR, -1, Hex(0x3FE), 10, 10, 1f, -40f)
         insertCANSignal(Constants.brakeTempRL, -1, Hex(0x3FE), 20, 10, 1f, -40f)

--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -56,13 +56,8 @@ object Constants {
     const val rearTemp = "rearTemp"
     const val coolantFlow = "coolantFlow"
     const val chargeStatus = "chargeStatus"
-    const val chargeStatusConnected = 1f
+    const val chargeStatusActive = 1f
     const val chargeStatusInactive = 0f
-    const val chargeStatusEnabled = 5f
-    const val chargeStatusStandby = 2f
-    const val chargeStatusEVSETestActive = 3f
-    const val chargeStatusEVSETestPassed = 4f
-    const val chargeStatusFault = 6f
     const val uiSpeedTestBus0 = "uiSpeedTestBus0"
     const val indicatorLeft = "indicatorLeft"
     const val indicatorRight = "indicatorRight"


### PR DESCRIPTION
Original signal used to switch to the charging view is `PCS_hvChargeStatus` which doesn't seem to switch away from 0 on non-SUC DC chargers (at least ones i tested). This PR changes that to `BMS_chargeRequest`, which seems to reliably go from 0 to 1 (with no intermediate or alternate values) when *any* kind of charging is initiated.

Alternative to this might be `CP_chargeCablePresent` if switching to charging view as soon as the connector is plugged in is more desireable. This might actually not be a bad idea, as seeing the green gauge on the screen will remind you the car is still plugged in when getting ready to leave.

This fixes issue #12 