### PR TITLE
Add gearInvalid to gearState

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -42,6 +42,7 @@ object Constants {
     const val gearReverse = 2
     const val gearNeutral = 3
     const val gearDrive = 4
+    const val gearSNA = 7
     const val doorOpen = 1
     const val doorClosed = 2
     const val maxDischargePower = "maxDischargePower"

--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -37,6 +37,7 @@ object Constants {
     const val battAmps = "BattAmps"
     const val steeringAngle = "SteeringAngle"
     const val vehicleSpeed = "Vehicle Speed"
+    const val gearInvalid = 0
     const val gearPark  = 1
     const val gearReverse = 2
     const val gearNeutral = 3

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -507,7 +507,7 @@ class DashFragment : Fragment() {
                 var gearStartIndex = 0
                 var gearEndIndex = 0
                 gearState = gearStateVal.toInt()
-                if (gearStateVal.toInt() == Constants.gearInvalid) {
+                if (gearStateVal.toInt() == Constants.gearInvalid || gearStateVal.toInt() == Constants.gearSNA) {
                     binding.autopilotInactive.visibility = View.INVISIBLE
                     gearStartIndex = 0
                     gearEndIndex = 0
@@ -855,7 +855,7 @@ class DashFragment : Fragment() {
                 }
 
             }
-            if (gearState != Constants.gearPark && gearState != Constants.gearInvalid) {
+            if (gearState != Constants.gearPark && gearState != Constants.gearInvalid && gearState != Constants.gearSNA) {
                 it.getValue(Constants.leftVehicle)?.let { sensorVal ->
                     if ((sensorVal.toInt() < l1Distance) and (sensorVal.toInt() >= l2Distance)) {
                         binding.blindSpotLeft1a.visibility = View.VISIBLE

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -44,7 +44,7 @@ class DashFragment : Fragment() {
     private var HRSPRS: Boolean = false
     private var l2Distance: Int = 200
     private var l1Distance: Int = 300
-    private var gearState: Int = Constants.gearPark
+    private var gearState: Int = Constants.gearInvalid
     private lateinit var prefs: SharedPreferences
 
 
@@ -505,8 +505,14 @@ class DashFragment : Fragment() {
                 val gear: String = binding.PRND.text.toString()
                 var ss = SpannableString(gear)
                 var gearStartIndex = 0
-                var gearEndIndex = 1
+                var gearEndIndex = 0
                 gearState = gearStateVal.toInt()
+                if (gearStateVal.toInt() == Constants.gearInvalid) {
+                    binding.autopilotInactive.visibility = View.INVISIBLE
+                    gearStartIndex = 0
+                    gearEndIndex = 0
+
+                }
                 if (gearStateVal.toInt() == Constants.gearPark) {
                     binding.autopilotInactive.visibility = View.INVISIBLE
                     gearStartIndex = 0
@@ -849,7 +855,7 @@ class DashFragment : Fragment() {
                 }
 
             }
-            if (gearState != Constants.gearPark) {
+            if (gearState != Constants.gearPark && gearState != Constants.gearInvalid) {
                 it.getValue(Constants.leftVehicle)?.let { sensorVal ->
                     if ((sensorVal.toInt() < l1Distance) and (sensorVal.toInt() >= l2Distance)) {
                         binding.blindSpotLeft1a.visibility = View.VISIBLE
@@ -873,7 +879,7 @@ class DashFragment : Fragment() {
                     }
                 }
             } else {
-                // in park
+                // in park or off
 
 
                 binding.blindSpotLeft1a.visibility = View.INVISIBLE

--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -92,6 +92,7 @@ class MockCANService : CANService {
                 Constants.isSunUp to 1f,
                 Constants.uiSpeed to 65.0f,
                 Constants.uiSpeedUnits to 0f,
+                Constants.gearSelected to Constants.gearInvalid.toFloat(),
 
                 )))
 }


### PR DESCRIPTION
I noticed that when getting out of the car, candash will unhide the blindspot markers, because gearState will change from park to invalid, and the blindspot markers are only hidden while in park.

Additionally, the P would stay highlighted when gear is invalid.

This adds gearInvalid support for gearState, which will ensure blindspot markers stay hidden when the car turns off, and greys out the P as well to indicate the car is off.