### PR TITLE
Fix build error in mock service

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -102,10 +102,8 @@ class MockCANService : CANService {
                 Constants.uiSpeedUnits to 0f,
                 Constants.frontLeftDoorState to 1f,
                 Constants.drlMode to Constants.drlModePosition,
-                Constants.chargeStatus to Constants.chargeStatusActive
-            )))
+                Constants.chargeStatus to Constants.chargeStatusActive,
                 Constants.gearSelected to Constants.gearInvalid.toFloat(),
-
                 )))
 }
 /*


### PR DESCRIPTION
It appears during one of the PR merges a few extra `)` were added, breaking building of the app.