### PR TITLE
Prepare prefs and settings fragment for additional options

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -96,8 +96,21 @@ object Constants {
     const val brakeTempFR = "brakeTempFR"
     const val brakeTempRL = "brakeTempRL"
     const val brakeTempRR = "brakeTempRR"
-    const val showPerfGauges = 2f
-    const val showPowerGauges = 1f
-    const val showSimpleGauges = 0f
+
+    // Prefs
+    const val forceNightMode = "forceNightMode"
     const val gaugeMode = "gaugeMode"
+    const val showSimpleGauges = 0f
+    const val showRegularGauges = 1f
+    const val showFullGauges = 2f
+    const val hideOdometer = "hideOdometer"
+    const val hideBs = "hideBs"
+    const val hideSpeedLimit = "hideSpeedLimit"
+    const val blankDisplaySync = "blankDisplaySync"
+    const val tempInF = "tempInF"
+    const val powerUnits = "powerUnits"
+    const val powerUnitKw = 0f
+    const val powerUnitHp = 1f
+    const val powerUnitPs = 2f
+    const val torqueInLbfFt = "torqueInLbfFt"
 }

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -62,10 +62,22 @@ class DashFragment : Fragment() {
         get() = (this / Resources.getSystem().displayMetrics.density)
     val Float.px: Float
         get() = (this * Resources.getSystem().displayMetrics.density)
-    val Float.kmh: Float
+    // Distance conversions
+    val Float.miToKm: Float
         get() = (this / .621371).toFloat()
-    val Float.mph: Float
+    val Float.kmToMi: Float
         get() = (this * .621371).toFloat()
+    // Temperature conversions
+    val Float.cToF: Float
+        get() = ((this * 9/5) + 32).toFloat()
+    // Power conversions
+    val Float.kwToHp: Float
+        get() = (this * 1.34102).toFloat()
+    val Float.kwToPs: Float
+        get() = (this * 1.35962).toFloat()
+    // Torque conversions
+    val Float.nmToLbfFt: Float
+        get() = (this * 0.73756).toFloat()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -289,9 +301,9 @@ class DashFragment : Fragment() {
         viewModel = ViewModelProvider(requireActivity()).get(DashViewModel::class.java)
         var colorFrom: Int
         if (!prefContains(Constants.gaugeMode)) {
-            setPref(Constants.gaugeMode, 2f)
+            setPref(Constants.gaugeMode, Constants.showFullGauges)
         }
-        if (getBooleanPref("forceNightMode")) {
+        if (getBooleanPref(Constants.forceNightMode)) {
             colorFrom = getBackgroundColor(0)
         } else {
             colorFrom = getBackgroundColor(isSunUp(viewModel))
@@ -367,10 +379,10 @@ class DashFragment : Fragment() {
             return@setOnClickListener
         }
         binding.unit.setOnClickListener {
-            if (getPref(Constants.gaugeMode) < 2f) {
+            if (getPref(Constants.gaugeMode) < Constants.showFullGauges) {
                 setPref(Constants.gaugeMode, getPref(Constants.gaugeMode) + 1f)
             } else {
-                setPref(Constants.gaugeMode, 0f)
+                setPref(Constants.gaugeMode, Constants.showSimpleGauges)
             }
         }
 
@@ -381,7 +393,7 @@ class DashFragment : Fragment() {
 
 
         binding.speed.setOnLongClickListener {
-            setBooleanPref("forceNightMode", !getBooleanPref("forceNightMode"))
+            setBooleanPref(Constants.forceNightMode, !getBooleanPref(Constants.forceNightMode))
             return@setOnLongClickListener true
         }
 
@@ -485,7 +497,7 @@ class DashFragment : Fragment() {
                 if (power < getPref("minPower")) setPref("minPower", power)
             }
             //binding.power.text = "%.2f".format(power)
-            if (getPref(Constants.gaugeMode) > 0f) {
+            if (getPref(Constants.gaugeMode) > Constants.showSimpleGauges) {
                 binding.minpower.visibility = View.VISIBLE
                 binding.maxpower.visibility = View.VISIBLE
                 if (!getBooleanPref("HRSPRS")) {
@@ -519,7 +531,7 @@ class DashFragment : Fragment() {
             viewModel.getValue(Constants.autopilotState)?.let { autopilotStateVal ->
                 if (autopilotStateVal.toInt() > 2) {
                     gearColorSelected = requireContext().getColor(R.color.autopilot_blue)
-                } else if (isSunUp(viewModel) == 1 && !getBooleanPref("forceNightMode")) {
+                } else if (isSunUp(viewModel) == 1 && !getBooleanPref(Constants.forceNightMode)) {
                     gearColorSelected = Color.DKGRAY
                 } else {
                     gearColorSelected = Color.LTGRAY
@@ -570,7 +582,7 @@ class DashFragment : Fragment() {
 
              */
             // hide performance gauges if user has elected to hide them or if splitscreen mode
-            if ((getPref(Constants.gaugeMode) < 2f) || isSplitScreen()) {
+            if ((getPref(Constants.gaugeMode) < Constants.showFullGauges) || isSplitScreen()) {
                 for (leftSideUIView in leftSideUIViews()) {
                     leftSideUIView.visibility = View.INVISIBLE
                 }
@@ -657,7 +669,7 @@ class DashFragment : Fragment() {
                 binding.batttempgauge.setGauge((it.toFloat() + 40f) / 128)
             }
             it.getValue(Constants.autopilotHands)?.let { autopilotHandsVal ->
-                if (getBooleanPref("forceNightMode")) {
+                if (getBooleanPref(Constants.forceNightMode)) {
                     colorFrom = getBackgroundColor(0)
                 } else {
                     colorFrom = getBackgroundColor(isSunUp(viewModel))
@@ -665,7 +677,7 @@ class DashFragment : Fragment() {
                 //TODO: change colors to autopilot_blue constant
                 if ((autopilotHandsVal.toInt() > 2) and (autopilotHandsVal.toInt() < 15)) {
                     binding.APWarning.clearAnimation()
-                    if (getBooleanPref("forceNightMode")) {
+                    if (getBooleanPref(Constants.forceNightMode)) {
                         colorFrom = getBackgroundColor(0)
                     } else {
                         colorFrom = getBackgroundColor(isSunUp(viewModel))
@@ -719,7 +731,7 @@ class DashFragment : Fragment() {
                 binding.speed.text = vehicleSpeedVal.toInt().toString()
 
                 if (viewModel.getValue(Constants.uiSpeedUnits) != 0f) {
-                    sensingSpeedLimit = 35f.kmh.toInt()
+                    sensingSpeedLimit = 35f.miToKm.toInt()
                 }
                 if (vehicleSpeedVal.toInt() > sensingSpeedLimit) {
                     l1Distance = 400
@@ -963,11 +975,11 @@ class DashFragment : Fragment() {
             }
 
             it.getValue(Constants.odometer)?.let { odometerVal ->
-                if (prefs.getBooleanPref(Constants.odometer) == true) {
+                if (prefs.getBooleanPref(Constants.hideOdometer) == false) {
                     binding.odometer.visibility = View.VISIBLE
                     if (uiSpeedUnitsMPH == true) {
                         binding.odometer.text =
-                            ((odometerVal.toInt()) * .62).toInt().toString() + " mi"
+                            odometerVal.toFloat().kmToMi.toInt().toString() + " mi"
                     } else {
                         binding.odometer.text = odometerVal.toInt().toString() + " km"
                     }
@@ -986,7 +998,7 @@ class DashFragment : Fragment() {
             if (viewModel.getValue(Constants.autopilotState) != 3f) {
                 var bsBinding = binding.BSWarningLeft
                 var colorFrom = getBackgroundColor(1)
-                if (getBooleanPref("forceNightMode")) {
+                if (getBooleanPref(Constants.forceNightMode)) {
                     colorFrom = getBackgroundColor(0)
                 } else if (viewModel.getValue(Constants.isSunUp) != null) {
                     colorFrom = getBackgroundColor(viewModel.getValue(Constants.isSunUp)!!.toInt())
@@ -1114,7 +1126,7 @@ class DashFragment : Fragment() {
                         for (chargingHiddenView in chargingHiddenViews()) {
                             chargingHiddenView.visibility = View.VISIBLE
                         }
-                        if (getPref(Constants.gaugeMode) > 0f) {
+                        if (getPref(Constants.gaugeMode) > Constants.showSimpleGauges) {
                             for (minMaxchargingHiddenView in minMaxchargingHiddenViews()) {
                                 minMaxchargingHiddenView.visibility = View.VISIBLE
                             }
@@ -1154,7 +1166,7 @@ class DashFragment : Fragment() {
                                 chargingHiddenView.visibility = View.VISIBLE
                             }
                         }
-                        if (getPref(Constants.gaugeMode) > 0f) {
+                        if (getPref(Constants.gaugeMode) > Constants.showSimpleGauges) {
                             for (minMaxchargingHiddenView in minMaxchargingHiddenViews()) {
                                 minMaxchargingHiddenView.visibility = View.VISIBLE
                             }
@@ -1314,7 +1326,7 @@ class DashFragment : Fragment() {
         val window: Window? = activity?.window
 
         // Not using dark-mode for compatibility with older version of Android (pre-29)
-        if (sunUpVal == 0 || getBooleanPref("forceNightMode")) {
+        if (sunUpVal == 0 || getBooleanPref(Constants.forceNightMode)) {
             binding.powerBar.setDayValue(0)
             binding.fullbattery.setDayValue(0)
             binding.fronttorquegauge.setDayValue(0)
@@ -1482,7 +1494,7 @@ class DashFragment : Fragment() {
 
         fadeIn.setAnimationListener(object : Animation.AnimationListener {
             override fun onAnimationStart(animation: Animation?) {
-                if (getPref(Constants.gaugeMode) == 2f) {
+                if (getPref(Constants.gaugeMode) == Constants.showFullGauges) {
                     for (leftSideUIView in leftSideUIViews()) {
                         leftSideUIView.visibility = View.INVISIBLE
                     }
@@ -1561,7 +1573,7 @@ class DashFragment : Fragment() {
                         // in case split screen is turned off while door open
                         binding.speed.visibility = View.VISIBLE
                         binding.unit.visibility = View.VISIBLE
-                        if (getPref(Constants.gaugeMode) == 2f) {
+                        if (getPref(Constants.gaugeMode) == Constants.showFullGauges) {
                             for (leftSideUIView in leftSideUIViews()) {
                                 leftSideUIView.visibility = View.VISIBLE
                             }

--- a/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
@@ -29,52 +29,104 @@ class SettingsFragment() : Fragment() {
         prefs = requireContext().getSharedPreferences("dash", Context.MODE_PRIVATE)
         return binding.root
     }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(requireActivity()).get(DashViewModel::class.java)
 
-        binding.saveSettings.setOnClickListener{
+        binding.saveSettings.setOnClickListener {
             saveSettings()
         }
-        binding.cancelSettings.setOnClickListener{
+        binding.cancelSettings.setOnClickListener {
             launchInfoFragment()
         }
-        if (prefs.getBooleanPref("forceNightMode")) {
+        if (prefs.getBooleanPref(Constants.forceNightMode)) {
             binding.displaydark.isChecked = true
         } else {
             binding.displayauto.isChecked = true
         }
-        when (prefs.getPref(Constants.gaugeMode)){
-            2f -> binding.gaugemodefull.isChecked = true
-            1f -> binding.gaugemoderegular.isChecked = true
-            0f -> binding.gaugemodesimple.isChecked = true
+        when (prefs.getPref(Constants.gaugeMode)) {
+            Constants.showFullGauges -> binding.gaugemodefull.isChecked = true
+            Constants.showRegularGauges -> binding.gaugemoderegular.isChecked = true
+            Constants.showSimpleGauges -> binding.gaugemodesimple.isChecked = true
         }
-        binding.showodo.isChecked = prefs.getBooleanPref(Constants.odometer)
+        // These are inverted so that the default value (false) shows the object (show = !hide)
+        binding.showodo.isChecked = !prefs.getBooleanPref(Constants.hideOdometer)
+        binding.showBs.isChecked = !prefs.getBooleanPref(Constants.hideBs)
+        binding.showSpeedLimit.isChecked = !prefs.getBooleanPref(Constants.hideSpeedLimit)
+        // This is not inverted, because defaulting to blank display makes the app appear broken on first launch
+        binding.blankDisplaySync.isChecked = prefs.getBooleanPref(Constants.blankDisplaySync)
+
+        if (prefs.getBooleanPref(Constants.tempInF)) {
+            binding.tempUnitF.isChecked = true
+        } else {
+            binding.tempUnitC.isChecked = true
+        }
+        when (prefs.getPref(Constants.powerUnits)) {
+            Constants.powerUnitKw -> binding.powerUnitKw.isChecked = true
+            Constants.powerUnitHp -> binding.powerUnitHp.isChecked = true
+            Constants.powerUnitPs -> binding.powerUnitPs.isChecked = true
+        }
+        if (prefs.getBooleanPref(Constants.torqueInLbfFt)) {
+            binding.torqueUnitLbf.isChecked = true
+        } else {
+            binding.torqueUnitNm.isChecked = true
+        }
 
     }
 
 
-
-    private fun saveSettings(){
+    private fun saveSettings() {
         when (binding.displaysettings.checkedRadioButtonId) {
-            R.id.displaydark -> prefs.setBooleanPref("forceNightMode", true)
-            R.id.displayauto -> prefs.setBooleanPref("forceNightMode", false)
+            R.id.displaydark -> prefs.setBooleanPref(Constants.forceNightMode, true)
+            R.id.displayauto -> prefs.setBooleanPref(Constants.forceNightMode, false)
         }
-        // val radioButton: RadioButton? = binding.gaugemode.findViewById<RadioButton>(binding.gaugemode.checkedRadioButtonId)
-        when(binding.gaugemode.checkedRadioButtonId){
-            R.id.gaugemodefull -> prefs.setPref(Constants.gaugeMode, 2f)
-            R.id.gaugemoderegular -> prefs.setPref(Constants.gaugeMode, 1f)
-            R.id.gaugemodesimple -> prefs.setPref(Constants.gaugeMode, 0f)
+        when (binding.gaugemode.checkedRadioButtonId) {
+            R.id.gaugemodefull -> prefs.setPref(Constants.gaugeMode, Constants.showFullGauges)
+            R.id.gaugemoderegular -> prefs.setPref(Constants.gaugeMode, Constants.showRegularGauges)
+            R.id.gaugemodesimple -> prefs.setPref(Constants.gaugeMode, Constants.showSimpleGauges)
         }
-        if (binding.showodo.isChecked){
-            prefs.setBooleanPref(Constants.odometer, true)
+        // These are inverted so that the default value (false) shows the object (show = !hide)
+        if (binding.showodo.isChecked) {
+            prefs.setBooleanPref(Constants.hideOdometer, false)
         } else {
-            prefs.setBooleanPref(Constants.odometer, false)
+            prefs.setBooleanPref(Constants.hideOdometer, true)
+        }
+        if (binding.showBs.isChecked) {
+            prefs.setBooleanPref(Constants.hideBs, false)
+        } else {
+            prefs.setBooleanPref(Constants.hideBs, true)
+        }
+        if (binding.showSpeedLimit.isChecked) {
+            prefs.setBooleanPref(Constants.hideSpeedLimit, false)
+        } else {
+            prefs.setBooleanPref(Constants.hideSpeedLimit, true)
+        }
+        // This is not inverted, because defaulting to blank display makes the app appear broken on first launch
+        if (binding.blankDisplaySync.isChecked) {
+            prefs.setBooleanPref(Constants.blankDisplaySync, true)
+        } else {
+            prefs.setBooleanPref(Constants.blankDisplaySync, false)
+        }
+        when (binding.tempUnits.checkedRadioButtonId) {
+            R.id.tempUnitC -> prefs.setBooleanPref(Constants.tempInF, false)
+            R.id.tempUnitF -> prefs.setBooleanPref(Constants.tempInF, true)
+        }
+        when (binding.powerUnits.checkedRadioButtonId) {
+            R.id.powerUnitKw -> prefs.setPref(Constants.powerUnits, Constants.powerUnitKw)
+            R.id.powerUnitHp -> prefs.setPref(Constants.powerUnits, Constants.powerUnitHp)
+            R.id.powerUnitPs -> prefs.setPref(Constants.powerUnits, Constants.powerUnitPs)
+        }
+        when (binding.torqueUnits.checkedRadioButtonId) {
+            R.id.torqueUnitNm -> prefs.setBooleanPref(Constants.torqueInLbfFt, false)
+            R.id.torqueUnitLbf -> prefs.setBooleanPref(Constants.torqueInLbfFt, true)
         }
         launchInfoFragment()
     }
-    private fun launchInfoFragment(){
+
+    private fun launchInfoFragment() {
         viewModel.switchToInfoFragment()
     }
+
     private fun setPref(name: String, value: Float) {
         with(prefs.edit()) {
             putFloat(name, value)

--- a/android/app/src/main/res/layout/fragment_settings.xml
+++ b/android/app/src/main/res/layout/fragment_settings.xml
@@ -5,101 +5,259 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/day_background">
+
     <TextView
+        android:id="@+id/display_mode_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="150dp"
-        android:layout_marginLeft="100dp"
-        android:textSize="18dp"
+        android:paddingLeft="10dp"
+        android:paddingTop="10dp"
         android:text="Display Mode"
-        android:textStyle="bold"
-        android:id="@+id/txtView"/>
+        android:textSize="18dp"
+        android:textStyle="bold" />
+
     <RadioGroup
+        android:id="@+id/displaysettings"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:id="@+id/displaysettings"
-        app:layout_constraintTop_toBottomOf="@id/txtView">
+        android:paddingLeft="10dp"
+        app:layout_constraintTop_toBottomOf="@id/display_mode_label">
+
         <RadioButton
             android:id="@+id/displayauto"
-            android:layout_width="wrap_content"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:text="Automatic"/>
+            android:text="Automatic" />
+
         <RadioButton
             android:id="@+id/displaydark"
-            android:layout_width="wrap_content"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:text="Dark"/>
+            android:text="Dark" />
     </RadioGroup>
+
+    <TextView
+        android:id="@+id/gaugemodelabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingLeft="10dp"
+        android:paddingTop="10dp"
+        android:text="Gauge Mode"
+        android:textSize="18dp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/displaysettings" />
+
+    <RadioGroup
+        android:id="@+id/gaugemode"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingLeft="10dp"
+
+        app:layout_constraintTop_toBottomOf="@id/gaugemodelabel">
+
+        <RadioButton
+            android:id="@+id/gaugemodefull"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Full" />
+
+        <RadioButton
+            android:id="@+id/gaugemoderegular"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Regular" />
+
+        <RadioButton
+            android:id="@+id/gaugemodesimple"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Simple" />
+    </RadioGroup>
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelinevleft"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+
+        app:layout_constraintGuide_percent=".333" />
+
+    <TextView
+        android:id="@+id/displayOptionsLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingLeft="10dp"
+        android:paddingTop="10dp"
+        android:text="Display Options"
+        android:textSize="18dp"
+        android:textStyle="bold"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft" />
 
     <CheckBox
         android:id="@+id/showodo"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Display Odometer"
-        app:layout_constraintTop_toBottomOf="@id/displaysettings"/>
+        android:layout_marginLeft="10dp"
+        android:text="Show Odometer"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
+        app:layout_constraintTop_toBottomOf="@id/displayOptionsLabel" />
+
+    <CheckBox
+        android:id="@+id/showBs"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:text="Show Blindspot Arcs"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
+        app:layout_constraintTop_toBottomOf="@id/showodo" />
+
+    <CheckBox
+        android:id="@+id/showSpeedLimit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:text="Show Speed Limit"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
+        app:layout_constraintTop_toBottomOf="@id/showBs" />
+
+    <CheckBox
+        android:id="@+id/blankDisplaySync"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:text="Blackout Screen w/ Center Display"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
+        app:layout_constraintTop_toBottomOf="@id/showSpeedLimit" />
 
     <TextView
+        android:id="@+id/blankDisplayHint"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:paddingLeft="20dp"
+        android:text="Long-press left side of screen to return\nto settings while display is off.\nRecommended only with OLED screens."
+        android:textSize="12dp"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
+        app:layout_constraintTop_toBottomOf="@id/blankDisplaySync" />
 
-        android:textSize="18dp"
-        android:text="Gauge Mode"
-        android:textStyle="bold"
-        android:id="@+id/gaugemodelabel"
-        app:layout_constraintTop_toBottomOf="@id/showodo"/>
-    <RadioGroup
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:id="@+id/gaugemode"
 
-        app:layout_constraintTop_toBottomOf="@id/gaugemodelabel">
-        <RadioButton
-            android:id="@+id/gaugemodefull"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Full"/>
-        <RadioButton
-            android:id="@+id/gaugemoderegular"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Regular"/>
-        <RadioButton
-            android:id="@+id/gaugemodesimple"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Simple"/>
-    </RadioGroup>
     <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelinevright"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/guidelinev"
         android:orientation="vertical"
 
-        app:layout_constraintGuide_percent=".5"/>
+        app:layout_constraintGuide_percent=".667" />
+
+    <TextView
+        android:id="@+id/unitsLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingLeft="10dp"
+        android:paddingTop="10dp"
+        android:text="Display Units"
+        android:textSize="18dp"
+        android:textStyle="bold"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevright" />
+
+    <RadioGroup
+        android:id="@+id/tempUnits"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingLeft="10dp"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevright"
+        app:layout_constraintTop_toBottomOf="@id/unitsLabel">
+
+        <RadioButton
+            android:id="@+id/tempUnitC"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Celcius" />
+
+        <RadioButton
+            android:id="@+id/tempUnitF"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Fahrenheit" />
+    </RadioGroup>
+
+    <RadioGroup
+        android:id="@+id/powerUnits"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:orientation="vertical"
+        android:paddingLeft="10dp"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevright"
+        app:layout_constraintTop_toBottomOf="@id/tempUnits">
+
+        <RadioButton
+            android:id="@+id/powerUnitKw"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Kilowatt" />
+
+        <RadioButton
+            android:id="@+id/powerUnitHp"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Horsepower" />
+
+        <RadioButton
+            android:id="@+id/powerUnitPs"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Metric Horsepower" />
+    </RadioGroup>
+
+    <RadioGroup
+        android:id="@+id/torqueUnits"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:orientation="vertical"
+        android:paddingLeft="10dp"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevright"
+        app:layout_constraintTop_toBottomOf="@id/powerUnits">
+
+        <RadioButton
+            android:id="@+id/torqueUnitNm"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Newton-metre" />
+
+        <RadioButton
+            android:id="@+id/torqueUnitLbf"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="MURICA (lbf⋅ft)" />
+    </RadioGroup>
+
     <Button
         android:id="@+id/save_settings"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_margin="10dp"
+        android:gravity="center"
         android:text="Save"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toRightOf="@id/guidelinev"
-        android:gravity="center"
+        app:layout_constraintRight_toLeftOf="@id/guidelinevright"
 
         />
+
     <Button
         android:id="@+id/cancel_settings"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_margin="10dp"
+        android:gravity="center"
         android:text="Cancel"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toLeftOf="@id/guidelinev"
-        android:gravity="center"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
 
         />
 


### PR DESCRIPTION
This is a base branch for the implementation of each of the new options in child branches, to prevent merge conflict hell from adding so many settings in 1 place at the same time.

This also updates the names of preferences to a form where the default value for every preference is false or 0.

### Default options:
- Display Mode = Automatic
- Gauge Mode = Simple
- Show Odo = True
- Show Blindspot = True
- Show Speed Limit = True
- Blackout Screen = False
- Temperature = C
- Power = kW
- Torque = nm

### Tests:
- ensured default settings apply after clearing storage/cache
- ensured settings updated after Save, did not update after Cancel
- ensured existing prefs (forceDarkMode, gaugemode, showodo) still functioned as expected.

![image](https://user-images.githubusercontent.com/54586926/183262960-a121d224-83b4-4c80-9165-42d6b21f5ede.png)
(screenshot does not represent default settings)