### PR TITLE
Never turn off screen while in gear

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -498,7 +498,9 @@ class DashFragment : Fragment() {
             }
 
             it.getValue(Constants.displayOn)?.let { displayOnVal ->
-                if (displayOnVal.toFloat() == 0f && prefs.getBooleanPref(Constants.blankDisplaySync)) {
+                if (displayOnVal.toFloat() == 0f && prefs.getBooleanPref(Constants.blankDisplaySync)
+                    // Never turn off screen if in gear
+                    && gearState != Constants.gearDrive && gearState != Constants.gearReverse) {
                     binding.blackout.visibility = View.VISIBLE
 
                     if (!blackoutToastToggle) {

--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -81,7 +81,8 @@ class MockCANService : CANService {
 
                 Constants.battVolts to 390f,
                 Constants.uiSpeed to 0.0f,
-                Constants.displayOn to 1f,
+                // display should stay on because gear is in drive
+                Constants.displayOn to 0f,
 
                 Constants.frontLeftDoorState to 2f,
                 Constants.drlMode to Constants.drlModeDrl,
@@ -118,8 +119,13 @@ class MockCANService : CANService {
                 Constants.gearSelected to Constants.gearInvalid.toFloat(),
                 Constants.displayOn to 1f,
                 Constants.fusedSpeedLimit to Constants.fusedSpeedSNA
-
-                )))
+            )),
+            CarState(mutableMapOf(
+                // display will turn off if the pref is enabled
+                Constants.gearSelected to Constants.gearPark.toFloat(),
+                Constants.displayOn to 0f,
+            ))
+        )
 
 
 }


### PR DESCRIPTION
This change ensures the display doesn't turn off when the center display turns off while in Drive or Reverse.
This is useful for when rebooting the MCU while driving (it keeps the candash display on)

This only applies to users with the blackout screen preference enabled.