### PR TITLE
Automatically determine bus IDs and warn for missing signals

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
+++ b/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
@@ -13,16 +13,25 @@ class CANSignalHelper {
     }
 
     private val mNameSignalMap = HashMap<String, CANSignal>()
-    private val mFrameSignalMap : MutableMap<Hex, MutableList<CANSignal>>  = mutableMapOf()
+    private val mBusFrameSignalMap : MutableMap<Int, MutableMap<Hex, MutableList<CANSignal>>>  = mutableMapOf()
 
     fun clearFiltersPacket() : ByteArray {
         return byteArrayOf(CLEAR_FILTERS_BYTE);
     }
 
-    fun addFilterPackets(signalNamesToUse: List<String>) : List<ByteArray> {
+    fun addFilterPackets(signalNamesToUse: List<String>, flipBus: Boolean) : List<ByteArray> {
         return signalsToUse(signalNamesToUse).chunked(MAX_FILTERS).map { CANSignals ->
             CANSignals.fold(mutableListOf(ADD_FILTERS_BYTE)) { byteList, CANSignal ->
-                byteList.add(CANSignal.busId.toByte())
+                if (flipBus){
+                    val busID = when (CANSignal.busId){
+                        Constants.chassisBus -> Constants.vehicleBus
+                        Constants.vehicleBus -> Constants.chassisBus
+                        else -> Constants.anyBus
+                    }
+                    byteList.add(busID.toByte())
+                } else {
+                    byteList.add(CANSignal.busId.toByte())
+                }
                 byteList.addAll(CANSignal.frameId.byteArray.asList())
                 Log.v(TAG, "frame id in socket filter:" + CANSignal.frameId.hexString)
                 byteList
@@ -48,93 +57,101 @@ class CANSignalHelper {
         return mNameSignalMap
     }
 
-    fun getSignalsForFrame(frame: Hex) : List<CANSignal> {
-        return mFrameSignalMap[frame] ?: listOf()
+    fun getSignalsForFrame(bus: Int, frame: Hex) : List<CANSignal> {
+        // Specific bus should take precedence
+        if (mBusFrameSignalMap[bus]?.containsKey(frame) == true){
+            return mBusFrameSignalMap[bus]?.get(frame) ?: listOf()
+        }
+        // Otherwise try the "anyBus" (-1) map
+        return mBusFrameSignalMap[Constants.anyBus]?.get(frame) ?: listOf()
     }
     fun insertCANSignal(name:String, busId:Int, frameId:Hex, startBit:Int, bitLength:Int, factor:Float, offset:Float,serviceIndex:Int = 0, muxIndex:Int = 0, signed:Boolean = false){
         val CANSignal = CANSignal(name, busId, frameId, startBit, bitLength, factor, offset, serviceIndex, muxIndex, signed)
         mNameSignalMap.put(CANSignal.name, CANSignal)
-        addToMapList(mFrameSignalMap, CANSignal.frameId, CANSignal)
+        addToMapList(mBusFrameSignalMap, CANSignal.busId, CANSignal.frameId, CANSignal)
     }
     fun createCANSignals() {
 
-        insertCANSignal(Constants.stateOfCharge, -1, Hex(0x33A), 48, 7, 1f, 0f)
-        insertCANSignal(Constants.battVolts, -1, Hex(0x132), 0, 16, 0.01f, 0f)
-        insertCANSignal(Constants.battAmps, -1, Hex(0x132), 16, 16, -.1f, 0f, signed=true)
+        insertCANSignal(Constants.stateOfCharge, Constants.vehicleBus, Hex(0x33A), 48, 7, 1f, 0f)
+        insertCANSignal(Constants.battVolts, Constants.vehicleBus, Hex(0x132), 0, 16, 0.01f, 0f)
+        insertCANSignal(Constants.battAmps, Constants.vehicleBus, Hex(0x132), 16, 16, -.1f, 0f, signed=true)
 
-        insertCANSignal(Constants.uiSpeed, -1, Hex(0x257), 24, 9, 1f, 0f)
-        //insertCANSignal(Constants.uiSpeedHighSpeed, -1, Hex(0x257), 34, 9, 1f, 0f)
-        insertCANSignal(Constants.fusedSpeedLimit, -1, Hex(0x399), 8, 5, 5f, 0f)
-        insertCANSignal(Constants.uiSpeedUnits, -1, Hex(0x257), 33, 1, 1f, 0f)
-        insertCANSignal(Constants.blindSpotLeft, -1, Hex(0x399), 4, 2, 1f, 0f)
-        insertCANSignal(Constants.blindSpotRight, -1, Hex(0x399), 6, 2, 1f, 0f)
-        //insertCANSignal(Constants.displayBrightnessLev, 0, Hex(0x273), 32, 8, .5f, 0)
-        insertCANSignal(Constants.uiRange, -1, Hex(0x33A), 0, 10, 1f, 0f)
-        insertCANSignal(Constants.turnSignalLeft, -1, Hex(0x3F5), 0, 2, 1f, 0f)
-        insertCANSignal(Constants.turnSignalRight, -1, Hex(0x3F5), 2, 2, 1f, 0f)
+        insertCANSignal(Constants.uiSpeed, Constants.vehicleBus, Hex(0x257), 24, 9, 1f, 0f)
+        //insertCANSignal(Constants.uiSpeedHighSpeed, Constants.vehicleBus, Hex(0x257), 34, 9, 1f, 0f)
+        insertCANSignal(Constants.fusedSpeedLimit, Constants.chassisBus, Hex(0x399), 8, 5, 5f, 0f)
+        insertCANSignal(Constants.uiSpeedUnits, Constants.vehicleBus, Hex(0x257), 33, 1, 1f, 0f)
+        insertCANSignal(Constants.blindSpotLeft, Constants.chassisBus, Hex(0x399), 4, 2, 1f, 0f)
+        insertCANSignal(Constants.blindSpotRight, Constants.chassisBus, Hex(0x399), 6, 2, 1f, 0f)
+        //insertCANSignal(Constants.displayBrightnessLev, Constants.vehicleBus, Hex(0x273), 32, 8, .5f, 0)
+        insertCANSignal(Constants.uiRange, Constants.vehicleBus, Hex(0x33A), 0, 10, 1f, 0f)
+        insertCANSignal(Constants.turnSignalLeft, Constants.vehicleBus, Hex(0x3F5), 0, 2, 1f, 0f)
+        insertCANSignal(Constants.turnSignalRight, Constants.vehicleBus, Hex(0x3F5), 2, 2, 1f, 0f)
 
-        insertCANSignal(Constants.lowBeamLeft, -1, Hex(0x3F5), 28, 2, 1f, 0f)
-        insertCANSignal(Constants.highBeamRequest, -1, Hex(0x3F5), 58, 1, 1f, 0f)
-        insertCANSignal(Constants.autoHighBeamEnabled, -1, Hex(0x273), 41, 1, 1f, 0f)
-        insertCANSignal(Constants.highLowBeamDecision, -1, Hex(0x3E9), 11, 2, 1f, 0f)
-        insertCANSignal(Constants.highBeamStalkStatus, -1, Hex(0x249), 12, 2, 1f, 0f)
-        insertCANSignal(Constants.frontFogSwitch, -1, Hex(0x273), 3, 1, 1f, 0f)
-        insertCANSignal(Constants.rearFogSwitch, -1, Hex(0x273), 23, 1, 1f, 0f)
+        insertCANSignal(Constants.lowBeamLeft, Constants.vehicleBus, Hex(0x3F5), 28, 2, 1f, 0f)
+        insertCANSignal(Constants.highBeamRequest, Constants.vehicleBus, Hex(0x3F5), 58, 1, 1f, 0f)
+        insertCANSignal(Constants.autoHighBeamEnabled, Constants.vehicleBus, Hex(0x273), 41, 1, 1f, 0f)
+        insertCANSignal(Constants.highLowBeamDecision, Constants.vehicleBus, Hex(0x3E9), 11, 2, 1f, 0f)
+        insertCANSignal(Constants.highBeamStalkStatus, Constants.vehicleBus, Hex(0x249), 12, 2, 1f, 0f)
+        insertCANSignal(Constants.frontFogSwitch, Constants.vehicleBus, Hex(0x273), 3, 1, 1f, 0f)
+        insertCANSignal(Constants.rearFogSwitch, Constants.vehicleBus, Hex(0x273), 23, 1, 1f, 0f)
 
-        insertCANSignal(Constants.isSunUp, -1, Hex(0x2D3), 25, 2, 1f, 0f)
-        //insertCANSignal(Constants.rearLeftVehicle, 1, Hex(0x22E), 36, 9, 1f, 0f)
-        //insertCANSignal(Constants.rearRightVehicle, 1, Hex(0x22E), 9, 9, 1f, 0f)
-        insertCANSignal(Constants.leftVehicle, -1, Hex(0x22E), 45, 9, 1f, 0f)
-        insertCANSignal(Constants.rightVehicle, -1, Hex(0x22E), 0, 9, 1f, 0f)
-        insertCANSignal(Constants.autopilotState, -1, Hex(0x399), 0, 4, 1f, 0f)
-        insertCANSignal(Constants.autopilotHands, -1, Hex(0x399), 42, 4, 1f, 0f)
-        insertCANSignal(Constants.cruiseControlSpeed, -1, Hex(0x368), 32, 9, .5f, 0f)
-        insertCANSignal(Constants.maxSpeedAP, -1, Hex(0x368), 32, 9, .5f, 0f)
-        insertCANSignal(Constants.liftgateState, -1, Hex(0x103), 56, 4, 1f, 0f)
-        insertCANSignal(Constants.frunkState, -1, Hex(0x2E1), 3, 4, 1f, 0f, 3, 0)
-        //insertCANSignal(Constants.conditionalSpeedLimit, -1, Hex(0x3D9), 56, 5, 5f, 0f)
-        //insertCANSignal(Constants.solarAngle, 0, Hex(0x2D3), 32, 8, 1f, 0, signed = true)
-        insertCANSignal(Constants.gearSelected, -1, Hex(0x118), 21, 3, 1f, 0f)
-        insertCANSignal(Constants.frontLeftDoorState, -1, Hex(0x102), 0, 4, 1f, 0f)
-        insertCANSignal(Constants.frontRightDoorState, -1, Hex(0x103), 0, 4, 1f, 0f)
-        insertCANSignal(Constants.rearLeftDoorState, -1, Hex(0x102), 4, 4, 1f, 0f)
-        insertCANSignal(Constants.rearRightDoorState, -1, Hex(0x103), 4, 4, 1f, 0f)
-        insertCANSignal(Constants.steeringAngle, -1, Hex(0x129), 16, 14, .1f, -819.2f)
-        insertCANSignal(Constants.frontTorque, -1, Hex(0x1D5), 21, 13, .222f, 0f, signed = true)
-        insertCANSignal(Constants.rearTorque, -1, Hex(0x1D8), 21, 13, .222f, 0f, signed = true)
-        insertCANSignal(Constants.battBrickMin, -1, Hex(0x332), 24, 8, .5f, -40f, 2, 0)
-        insertCANSignal(Constants.driveConfig, -1, Hex(0x7FF), 10, 1, 1f, 0f, 8, 1)
-        insertCANSignal(Constants.mapRegion, -1, Hex(0x7FF), 8, 4, 1f, 0f, 8, 3)
-        insertCANSignal(Constants.frontTemp, -1, Hex(0x396), 24, 8, 1f, -40f)
-        insertCANSignal(Constants.rearTemp, -1, Hex(0x395), 24, 8, 1f, -40f)
-        insertCANSignal(Constants.coolantFlow, -1, Hex(0x241), 22, 9, .1f, 0f)
-        insertCANSignal(Constants.chargeStatus, -1, Hex(0x212), 29, 1, 1f, 0f)
-        insertCANSignal(Constants.brakeTempFL, -1, Hex(0x3FE), 0, 10, 1f, -40f)
-        insertCANSignal(Constants.brakeTempFR, -1, Hex(0x3FE), 10, 10, 1f, -40f)
-        insertCANSignal(Constants.brakeTempRL, -1, Hex(0x3FE), 20, 10, 1f, -40f)
-        insertCANSignal(Constants.brakeTempRR, -1, Hex(0x3FE), 30, 10, 1f, -40f)
-        insertCANSignal(Constants.displayOn, -1, Hex(0x353), 5, 1, 1f, 0f)
+        insertCANSignal(Constants.isSunUp, Constants.chassisBus, Hex(0x2D3), 25, 2, 1f, 0f)
+        //insertCANSignal(Constants.rearLeftVehicle, Constants.chassisBus, Hex(0x22E), 36, 9, 1f, 0f)
+        //insertCANSignal(Constants.rearRightVehicle, Constants.chassisBus, Hex(0x22E), 9, 9, 1f, 0f)
+        insertCANSignal(Constants.leftVehicle, Constants.chassisBus, Hex(0x22E), 45, 9, 1f, 0f)
+        insertCANSignal(Constants.rightVehicle, Constants.chassisBus, Hex(0x22E), 0, 9, 1f, 0f)
+        insertCANSignal(Constants.autopilotState, Constants.chassisBus, Hex(0x399), 0, 4, 1f, 0f)
+        insertCANSignal(Constants.autopilotHands, Constants.chassisBus, Hex(0x399), 42, 4, 1f, 0f)
+        // These don't exist anymore. 0x368 is absent on chassis bus, and is something different on vehicle bus:
+        //insertCANSignal(Constants.cruiseControlSpeed, Constants.chassisBus, Hex(0x368), 32, 9, .5f, 0f)
+        //insertCANSignal(Constants.maxSpeedAP, Constants.chassisBus, Hex(0x368), 32, 9, .5f, 0f)
+        insertCANSignal(Constants.liftgateState, Constants.vehicleBus, Hex(0x103), 56, 4, 1f, 0f)
+        insertCANSignal(Constants.frunkState, Constants.vehicleBus, Hex(0x2E1), 3, 4, 1f, 0f, 3, 0)
+        //insertCANSignal(Constants.conditionalSpeedLimit, Constants.chassisBus, Hex(0x3D9), 56, 5, 5f, 0f)
+        //insertCANSignal(Constants.solarAngle, Constants.chassisBus, Hex(0x2D3), 32, 8, 1f, 0, signed = true)
+        insertCANSignal(Constants.gearSelected, Constants.vehicleBus, Hex(0x118), 21, 3, 1f, 0f)
+        insertCANSignal(Constants.frontLeftDoorState, Constants.vehicleBus, Hex(0x102), 0, 4, 1f, 0f)
+        insertCANSignal(Constants.frontRightDoorState, Constants.vehicleBus, Hex(0x103), 0, 4, 1f, 0f)
+        insertCANSignal(Constants.rearLeftDoorState, Constants.vehicleBus, Hex(0x102), 4, 4, 1f, 0f)
+        insertCANSignal(Constants.rearRightDoorState, Constants.vehicleBus, Hex(0x103), 4, 4, 1f, 0f)
+        insertCANSignal(Constants.steeringAngle, Constants.vehicleBus, Hex(0x129), 16, 14, .1f, -819.2f)
+        insertCANSignal(Constants.frontTorque, Constants.vehicleBus, Hex(0x1D5), 21, 13, .222f, 0f, signed = true)
+        insertCANSignal(Constants.rearTorque, Constants.vehicleBus, Hex(0x1D8), 21, 13, .222f, 0f, signed = true)
+        insertCANSignal(Constants.battBrickMin, Constants.vehicleBus, Hex(0x332), 24, 8, .5f, -40f, 2, 0)
+        insertCANSignal(Constants.driveConfig, Constants.vehicleBus, Hex(0x7FF), 10, 1, 1f, 0f, 8, 1)
+        insertCANSignal(Constants.mapRegion, Constants.vehicleBus, Hex(0x7FF), 8, 4, 1f, 0f, 8, 3)
+        insertCANSignal(Constants.frontTemp, Constants.vehicleBus, Hex(0x396), 24, 8, 1f, -40f)
+        insertCANSignal(Constants.rearTemp, Constants.vehicleBus, Hex(0x395), 24, 8, 1f, -40f)
+        insertCANSignal(Constants.coolantFlow, Constants.vehicleBus, Hex(0x241), 22, 9, .1f, 0f)
+        insertCANSignal(Constants.chargeStatus, Constants.vehicleBus, Hex(0x212), 29, 1, 1f, 0f)
+        insertCANSignal(Constants.brakeTempFL, Constants.vehicleBus, Hex(0x3FE), 0, 10, 1f, -40f)
+        insertCANSignal(Constants.brakeTempFR, Constants.vehicleBus, Hex(0x3FE), 10, 10, 1f, -40f)
+        insertCANSignal(Constants.brakeTempRL, Constants.vehicleBus, Hex(0x3FE), 20, 10, 1f, -40f)
+        insertCANSignal(Constants.brakeTempRR, Constants.vehicleBus, Hex(0x3FE), 30, 10, 1f, -40f)
+        insertCANSignal(Constants.displayOn, Constants.vehicleBus, Hex(0x353), 5, 1, 1f, 0f)
 
-        insertCANSignal(Constants.drlMode, -1, Hex(0x381), 5, 2, 1f, 0f, 5, 18 )
-        insertCANSignal(Constants.driverUnbuckled, -1, Hex(0x3A1), 32, 2, 1f, 0f, 1, 0)
-        insertCANSignal(Constants.passengerUnbuckled, -1, Hex(0x3A1), 34, 2, 1f, 0f, 1, 0)
-        insertCANSignal(Constants.heatBattery, -1, Hex(0x2E1), 63, 1, 1f, 0f, 3, 0 )
+        insertCANSignal(Constants.drlMode, Constants.vehicleBus, Hex(0x381), 5, 2, 1f, 0f, 5, 18 )
+        insertCANSignal(Constants.driverUnbuckled, Constants.vehicleBus, Hex(0x3A1), 32, 2, 1f, 0f, 1, 0)
+        insertCANSignal(Constants.passengerUnbuckled, Constants.vehicleBus, Hex(0x3A1), 34, 2, 1f, 0f, 1, 0)
+        insertCANSignal(Constants.heatBattery, Constants.vehicleBus, Hex(0x2E1), 63, 1, 1f, 0f, 3, 0 )
 
         // EPBR_telltaleLocal: 0 "LAMP_OFF" 1 "LAMP_RED_ON" 2 "LAMP_AMBER_ON" 3 "LAMP_RED_FLASH" 7 "SNA"
-        insertCANSignal(Constants.brakePark, 0, Hex(0x228), 39, 3, 1f, 0f)
+        insertCANSignal(Constants.brakePark, Constants.vehicleBus, Hex(0x228), 46, 3, 1f, 0f)
 
-        insertCANSignal(Constants.brakeHold, -1, Hex(0x2B6), 10, 1, 1f, 0f)
-        insertCANSignal(Constants.tpmsSoft, -1, Hex(0x123), 13, 1, 1f, 0f)
-        insertCANSignal(Constants.tpmsHard, -1, Hex(0x123), 12, 1, 1f, 0f)
+        insertCANSignal(Constants.brakeHold, Constants.vehicleBus, Hex(0x2B6), 10, 1, 1f, 0f)
+        insertCANSignal(Constants.tpmsSoft, Constants.vehicleBus, Hex(0x123), 13, 1, 1f, 0f)
+        insertCANSignal(Constants.tpmsHard, Constants.vehicleBus, Hex(0x123), 12, 1, 1f, 0f)
 
-        insertCANSignal(Constants.odometer, -1, Hex(0x3B6), 0, 32, 0.001f, 0f)
+        insertCANSignal(Constants.odometer, Constants.vehicleBus, Hex(0x3B6), 0, 32, 0.001f, 0f)
     }
 
-    private fun addToMapList(map: MutableMap<Hex, MutableList<CANSignal>>, key: Hex, value: CANSignal) {
-        if (map.containsKey(key)) {
-            map[key]?.add(value)
+    private fun addToMapList(map: MutableMap<Int, MutableMap<Hex, MutableList<CANSignal>>>, bus: Int, frameId: Hex, value: CANSignal) {
+        if (!map.containsKey(bus)) {
+            map[bus] = mutableMapOf(Pair(frameId, mutableListOf(value)))
+        }else if (map[bus]?.containsKey(frameId) == false) {
+            map[bus]?.set(frameId, mutableListOf(value))
         } else {
-            map[key] = mutableListOf(value)
+            map[bus]?.get(frameId)?.add(value)
         }
     }
 }

--- a/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
+++ b/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
@@ -136,7 +136,7 @@ class CANSignalHelper {
         insertCANSignal(Constants.heatBattery, Constants.vehicleBus, Hex(0x2E1), 63, 1, 1f, 0f, 3, 0 )
 
         // EPBR_telltaleLocal: 0 "LAMP_OFF" 1 "LAMP_RED_ON" 2 "LAMP_AMBER_ON" 3 "LAMP_RED_FLASH" 7 "SNA"
-        insertCANSignal(Constants.brakePark, Constants.vehicleBus, Hex(0x228), 46, 3, 1f, 0f)
+        insertCANSignal(Constants.brakePark, Constants.vehicleBus, Hex(0x228), 39, 3, 1f, 0f)
 
         insertCANSignal(Constants.brakeHold, Constants.vehicleBus, Hex(0x2B6), 10, 1, 1f, 0f)
         insertCANSignal(Constants.tpmsSoft, Constants.vehicleBus, Hex(0x123), 13, 1, 1f, 0f)

--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -1,6 +1,10 @@
 package app.candash.cluster
 
 object Constants {
+    // PandaService may flip these automatically
+    const val chassisBus = 0
+    const val vehicleBus = 1
+    const val anyBus = -1
     const val uiSpeed = "UISpeed"
     const val battVolts = "BattVolts"
     const val stateOfCharge = "UI_SOC"


### PR DESCRIPTION
This uses a known frame (`0x399`) of different lengths to determine which bus is which, this allows us to specify all of our signals on specific buses so we don't get noise from frames of the same ID on the wrong bus, and allows us to remove the custom logic that ignored frames of wrong sizes, etc.

This also includes the busID in the signal lookup so that we can use 2 frames of the same IDs from different buses (if we even have a need to do so).

Now when adding signals, use `Constants.vehicleBus` or `Constants.chassisBus` to specify the bus you expect the signal to be on. It's still possible to specify a signal from `Constants.anyBus` (-1) if you really want to, but is no longer needed and not recommended. It's better to try the bus you think it's on, and view the log for missing signal warnings to see if you picked the wrong bus.

This also adds a warning whenever signals are not being received in the last 5 seconds (if connected to a canserver) in order to identify if we have specified the wrong bus/frame/sb/mu for a given signal. This was crucial to testing that all signals work on their respective bus.

### Test Plan

Streamed pre-logged data from a panda server in both configurations:
- chassis bus = 0, vehicle bus = 1
- vehicle bus = 0, chassis bus = 1

Verified with the panda server that it was sending the correct filter requests regardless of which bus was which:
Example from when streaming data where vehicle bus = 0:
```
First, it always attempts chassis bus = 0 on startup:

[2022-09-03 14:08:10,013] [DEBUG] panda_client.py:_filter_clear:152 - (panda_client.192.168.86.105) Filter clear command received
[2022-09-03 14:08:10,064] [DEBUG] panda_client.py:process:45 - (panda_client.192.168.86.105) received: (raw)
[2022-09-03 14:08:10,064] [DEBUG] panda_client.py:_get_filter_info_from:138 - (panda_client.192.168.86.105) Filter item: bus=0, frame=918
[2022-09-03 14:08:10,064] [DEBUG] panda_client.py:_get_filter_info_from:138 - (panda_client.192.168.86.105) Filter item: bus=0, frame=851
[2022-09-03 14:08:10,065] [DEBUG] panda_client.py:_get_filter_info_from:138 - (panda_client.192.168.86.105) Filter item: bus=0, frame=826
[2022-09-03 14:08:10,065] [DEBUG] panda_client.py:_get_filter_info_from:138 - (panda_client.192.168.86.105) Filter item: bus=1, frame=558
(continued...)

Then it detects that chassis bus must be 1, and clears and sends new (flipped) filter request:

[2022-09-03 14:08:10,630] [DEBUG] panda_client.py:_filter_clear:152 - (panda_client.192.168.86.105) Filter clear command received
[2022-09-03 14:08:10,680] [DEBUG] panda_client.py:process:45 - (panda_client.192.168.86.105) received: (raw)
[2022-09-03 14:08:10,680] [DEBUG] panda_client.py:_get_filter_info_from:138 - (panda_client.192.168.86.105) Filter item: bus=1, frame=918
[2022-09-03 14:08:10,680] [DEBUG] panda_client.py:_get_filter_info_from:138 - (panda_client.192.168.86.105) Filter item: bus=1, frame=851
[2022-09-03 14:08:10,680] [DEBUG] panda_client.py:_get_filter_info_from:138 - (panda_client.192.168.86.105) Filter item: bus=1, frame=826
[2022-09-03 14:08:10,680] [DEBUG] panda_client.py:_get_filter_info_from:138 - (panda_client.192.168.86.105) Filter item: bus=0, frame=558
(continued...)
```

And tested the missing signals warning:
- Ensured that missing signal warnings were working using `cruiseControlSpeed` which does not exist anymore
  - `28774-28808/app.candash.cluster W/PandaService: Did not receive signal 'cruiseControlSpeed' in the last 5 seconds`
- Ensured that there were no missing signal warnings for any signal while streaming real car data
  - Note that I had to comment out `cruiseControlSpeed` and `maxSpeedAP` since they don't exist anymore
- Ensured there were no missing signal warnings when the canserver is disconnected

