### PR TITLE
Blackout and darkmode bug fixes

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -346,6 +346,8 @@ class DashFragment : Fragment() {
         val autopilotAnimation = ValueAnimator.ofObject(ArgbEvaluator(), colorFrom, colorTo)
         val blindspotAnimation = ValueAnimator.ofObject(ArgbEvaluator(), colorFrom, bsColorTo)
 
+        binding.blackout.visibility = View.GONE
+
         // milliseconds
         if (!isSplitScreen()) {
             for (topUIView in topUIViews()) {

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -312,6 +312,8 @@ class DashFragment : Fragment() {
         }
         if (prefs.getBooleanPref(Constants.forceNightMode)) {
             colorFrom = getBackgroundColor(0)
+            // Go ahead and load dark mode instead of waiting on a signal
+            setColors(0)
         } else {
             colorFrom = getBackgroundColor(isSunUp(viewModel))
         }


### PR DESCRIPTION
This fixes 2 bugs:

- App launches straight into blackout if not connected to a server (even if blackout feature is disabled)
  - blackout must be set to GONE at startup, this line appears to have unintentionally removed in #32 
- App launches into light mode if not connected to a server even though force dark mode is enabled
  - if not connected, it never has a isSunUp value to attempt to set the colors, and thus it never has a chance to set it to dark if dark mode is enabled.