### PR TITLE
Clear views when a signal goes missing (or disconnected from canserver)

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -1058,8 +1058,9 @@ class DashFragment : Fragment() {
                 binding.telltaleFogFront.visibility = View.INVISIBLE
             }
 
-            if ((it.getValue(Constants.driverUnbuckled) == 1f) or
-                (it.getValue(Constants.passengerUnbuckled) == 1f)) {
+            if ( gearState != Constants.gearSNA && gearState != Constants.gearInvalid &&
+                ((it.getValue(Constants.driverUnbuckled) == 1f) or
+                (it.getValue(Constants.passengerUnbuckled) == 1f))) {
                 binding.telltaleSeatbelt.visibility = View.VISIBLE
             } else {
                 binding.telltaleSeatbelt.visibility = View.INVISIBLE

--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -20,8 +20,8 @@ class MockCANService : CANService {
         withContext(pandaContext) {
             shutdown = false
             while (!shutdown) {
-                Thread.sleep(MS_BETWEEN_REQUESTS)
                 carStateFlow.value = mockCarStates()[count.getAndAdd(1) % mockCarStates().size]
+                Thread.sleep(MS_BETWEEN_REQUESTS)
                 yield()
             }
             // Clear carState after stopping

--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -24,6 +24,8 @@ class MockCANService : CANService {
                 carStateFlow.value = mockCarStates()[count.getAndAdd(1) % mockCarStates().size]
                 yield()
             }
+            // Clear carState after stopping
+            carStateFlow.value = CarState()
         }
     }
     override fun isRunning() : Boolean {

--- a/android/app/src/main/java/app/candash/cluster/PandaService.kt
+++ b/android/app/src/main/java/app/candash/cluster/PandaService.kt
@@ -122,6 +122,8 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
                                 Log.w(
                                     TAG,"Did not receive signal '$name' in the last $deltaSeconds seconds"
                                 )
+                                carState.carData.remove(name)
+                                carStateFlow.value = CarState(HashMap(carState.carData))
                             }
                         }
                         recentSignalsReceived.clear()
@@ -146,6 +148,8 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
                         )
                         pandaConnected = false
                         sendBye(getSocket())
+                        carState.carData.clear()
+                        carStateFlow.value = CarState(HashMap(carState.carData))
                         yield()
                         continue
                     }
@@ -185,6 +189,7 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
                 getSocket().close()
                 Log.d(TAG, "Socket closed")
                 carState.carData.clear()
+                carStateFlow.value = CarState(HashMap(carState.carData))
                 inShutdown = false
             } catch (exception: Exception) {
                 inShutdown = false

--- a/android/app/src/main/java/app/candash/cluster/PandaService.kt
+++ b/android/app/src/main/java/app/candash/cluster/PandaService.kt
@@ -188,8 +188,9 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
                 Log.d(TAG, "Socket disconnected")
                 getSocket().close()
                 Log.d(TAG, "Socket closed")
-                carState.carData.clear()
-                carStateFlow.value = CarState(HashMap(carState.carData))
+                // Don't clear carState when shutting down, because this happens when switching between apps and is very jarring
+                // carState.carData.clear()
+                // carStateFlow.value = CarState(HashMap(carState.carData))
                 inShutdown = false
             } catch (exception: Exception) {
                 inShutdown = false


### PR DESCRIPTION
This makes a few key changes:

- if a particular signal hasn't been received in at least 5 seconds, remove that signal from carState (and update flow)
- if we disconnect from a canserver (or mock server stopped), completely clear carState (and update flow)
- add logic to every individual view that if the signal it relies on is `null`, to hide the view (or set it to `""`)
  - typically this uses the elvis operator whenever we `.let` a value from carState to run logic only when the value is `null`
    - note the importance of avoiding `viewModel.getValue()` since that uses carState *history* which is not cleared
  - ...but every view is a bit different, sometimes instead of changing visibility, it was necessary to set the text to empty as other logic would just change the visibility back.

### Test plan

- testing disconnection of panda server
  - using a panda server, abruptly disconnected the server during several different scenarios:
    - driving with telltales on, blindspot arcs on, etc
    - charging
    - doors open
  - ensured that each time, all elements were cleared out and returned to default view (not stuck in charging view for example)
- testing disconnection of mock server
  - from each cycle of the mock server, would stop the server and quickly launch dash
  - after the 2 second mock wait expired the signals would be cleared
  - ensured that all views cleared at this point
- testing the loss of individual signals
  - connected to vehicle and vehicle "on" (after pressing brake pedal)
  - all expected views visible: speedo, temps, torque, etc
  - turned "off" car by opening charge port door
  - all views which are not expected disappeared after a short wait: speedo, motor temps, brake temps, torque, PRND

