### PR TITLE
Fix panda service exception when app is in background

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/PandaService.kt
+++ b/android/app/src/main/java/app/candash/cluster/PandaService.kt
@@ -32,6 +32,7 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
     private var lastHeartbeatTimestamp = 0L
     private val heartBeatIntervalMs = 4_000
     private val socketTimeoutMs = 1_000
+    private var socketTimeoutCounter = 0
     private val signalHelper = CANSignalHelper()
     private val pandaContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     private var signalsToRequest: List<String> = arrayListOf()
@@ -54,7 +55,7 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
     private fun getSocket(): DatagramSocket {
         if (!this::socket.isInitialized) {
             socket = DatagramSocket(null)
-            socket.soTimeout = heartBeatIntervalMs
+            socket.soTimeout = socketTimeoutMs
             socket.reuseAddress = true
         }
         return socket
@@ -62,7 +63,7 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
 
     private fun createSocket(): DatagramSocket {
         socket = DatagramSocket(null)
-        socket.soTimeout = heartBeatIntervalMs
+        socket.soTimeout = socketTimeoutMs
         socket.reuseAddress = true
         return socket
     }
@@ -140,6 +141,7 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
                             recentSignalsReceived.clear()
                             lastReceivedCheckTimestamp = System.currentTimeMillis()
                             pandaConnected = true
+                            socketTimeoutCounter = 0
                         }
                     } catch (socketTimeoutException: SocketTimeoutException) {
                         Log.w(
@@ -147,9 +149,13 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
                             "Socket timed out without receiving a packet on thread: ${Thread.currentThread().name}"
                         )
                         pandaConnected = false
+                        socketTimeoutCounter += 1
+                        if (socketTimeoutCounter == 3) {
+                            // one-shot clear data on 3rd timeout
+                            carState.carData.clear()
+                            carStateFlow.value = CarState(HashMap(carState.carData))
+                        }
                         sendBye(getSocket())
-                        carState.carData.clear()
-                        carStateFlow.value = CarState(HashMap(carState.carData))
                         yield()
                         continue
                     }
@@ -188,9 +194,6 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
                 Log.d(TAG, "Socket disconnected")
                 getSocket().close()
                 Log.d(TAG, "Socket closed")
-                // Don't clear carState when shutting down, because this happens when switching between apps and is very jarring
-                // carState.carData.clear()
-                // carStateFlow.value = CarState(HashMap(carState.carData))
                 inShutdown = false
             } catch (exception: Exception) {
                 inShutdown = false
@@ -260,6 +263,10 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
     }
 
     private fun sendBye(socket: DatagramSocket) {
+        if (!socket.isConnected) {
+            // In case we're already disconnected, don't fail dramatically when trying to send data
+            return
+        }
         // prepare data to be sent
         val udpOutputData = goodbye
 

--- a/android/app/src/main/java/app/candash/cluster/PandaService.kt
+++ b/android/app/src/main/java/app/candash/cluster/PandaService.kt
@@ -263,10 +263,6 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
     }
 
     private fun sendBye(socket: DatagramSocket) {
-        if (!socket.isConnected) {
-            // In case we're already disconnected, don't fail dramatically when trying to send data
-            return
-        }
         // prepare data to be sent
         val udpOutputData = goodbye
 
@@ -295,11 +291,15 @@ class PandaService(val sharedPreferences: SharedPreferences, val context: Contex
         try {
             socket.send(packet)
         } catch (ioException: IOException) {
-            Log.e(TAG, "IOException while sending data.", ioException)
-            if (!isBye) checkNetwork()
+            if (!isBye) {
+                Log.e(TAG, "IOException while sending data.", ioException)
+                checkNetwork()
+            }
         } catch (socketException: SocketException) {
-            Log.e(TAG, "SocketException while sending data.", socketException)
-            if (!isBye) checkNetwork()
+            if (!isBye) {
+                Log.e(TAG, "SocketException while sending data.", socketException)
+                checkNetwork()
+            }
         }
     }
 


### PR DESCRIPTION
This fixes the socket closed exception that occurs whenever switching between apps (candash in background) by not trying to send `bye` when already disconnected.

It also reduces the chance of the gauges flickering when coming across transient socket timeouts due to a weak signal or laggy canserver. It does this by shortening the timeout duration, but allowing for multiple timeouts (3) before it clears the carstate data.

Note that while the panda service will stay connected to the canserver for a short time while the app is in the background, the canserver would eventually disconnect candash because it won't see heartbeats while candash is in the background. If you rejoin candash after this, it reconnects very quickly without clearing data.

### Test plan

- while candash is open, stop canserver abruptly, ensure the car data clears after 3 seconds (3 timeouts at 1 second each)
- while canserver is running, switch between candash and other apps, ensuring that the gauges don't blank out when resuming candash
  - tested within a single heartbeat duration, canserver stays connected
  - tested longer than a single heartbeat duration, canserver disconnects, but quickly reconnects once switching back to candash
- switched between panda service and mock service multiple times, ensuring no odd behavior.