### PR TITLE
Use uSOE for battery level to match car display

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
+++ b/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
@@ -72,7 +72,8 @@ class CANSignalHelper {
     }
     fun createCANSignals() {
 
-        insertCANSignal(Constants.stateOfCharge, Constants.vehicleBus, Hex(0x33A), 48, 7, 1f, 0f)
+        // Technically uSOE (usable State Of Energy), this better matches what the car shows.
+        insertCANSignal(Constants.stateOfCharge, Constants.vehicleBus, Hex(0x33A), 56, 7, 1f, 0f)
         insertCANSignal(Constants.battVolts, Constants.vehicleBus, Hex(0x132), 0, 16, 0.01f, 0f)
         insertCANSignal(Constants.battAmps, Constants.vehicleBus, Hex(0x132), 16, 16, -.1f, 0f, signed=true, sna=3276.7f)
 


### PR DESCRIPTION
Updates the can signal to use uSOE which more accurately reflects what the car shows.

Pictures taken at same time:
![image](https://user-images.githubusercontent.com/54586926/193428151-1134e4f7-8511-40d7-9a5c-1b689b4c2296.png)
![image](https://user-images.githubusercontent.com/54586926/193428159-aaa36495-74ff-4778-a932-da94803682e6.png)
