### PR TITLE
Add historical efficiency calculations

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
     implementation "com.squareup.okhttp3:okhttp:3.5.0"
     implementation "com.google.guava:guava:31.0.1-android"
+    implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation "com.google.dagger:hilt-android:2.38.1"
     kapt "com.google.dagger:hilt-compiler:2.38.1"

--- a/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
+++ b/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
@@ -145,6 +145,8 @@ class CANSignalHelper {
         insertCANSignal(Constants.tpmsHard, Constants.vehicleBus, Hex(0x123), 12, 1, 1f, 0f)
 
         insertCANSignal(Constants.odometer, Constants.vehicleBus, Hex(0x3B6), 0, 32, 0.001f, 0f, sna=4294967.295f)
+        insertCANSignal(Constants.kwhDischargeTotal, Constants.vehicleBus, Hex(0x3D2), 0, 32, 0.001f, 0f, sna=4294967.295f)
+        insertCANSignal(Constants.kwhChargeTotal, Constants.vehicleBus, Hex(0x3D2), 32, 32, 0.001f, 0f, sna=4294967.295f)
     }
 
     private fun addToMapList(map: MutableMap<Int, MutableMap<Hex, MutableList<CANSignal>>>, bus: Int, frameId: Hex, value: CANSignal) {

--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -108,6 +108,8 @@ object Constants {
     const val tpmsSoft = "tpmsSoft"
     const val tpmsHard = "tpmsHard"
     const val odometer = "odometer"
+    const val kwhDischargeTotal = "kwhDischargeTotal"
+    const val kwhChargeTotal = "kwhChargeTotal"
     const val heatBattery = "heatBattery"
     const val conditionalSpeedLimit = "conditionalSpeedLimit"
     const val brakeTempFL = "brakeTempFL"
@@ -132,5 +134,12 @@ object Constants {
     const val powerUnitHp = 1f
     const val powerUnitPs = 2f
     const val torqueInLbfFt = "torqueInLbfFt"
-    const val hideInstEfficiency = "hideInstEfficiency"
+    const val hideEfficiency = "hideEfficiency"
+    const val efficiencyLookBack = "efficiencyLookBack"
+
+    // For efficiency history in prefs
+    const val kwhHistory = "kwhHistory"
+    const val parkedKwhHistory = "parkedKwhHistory"
+    const val parkedStartKwhDischarge = "parkedStartKwhDischarge"
+    const val parkedStartKwhCharge = "parkedStartKwhCharge"
 }

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -1132,7 +1132,6 @@ class DashFragment : Fragment() {
                 else {
                     binding.odometer.visibility = View.INVISIBLE
                 }
-                efficiencyCalculator.updateKwhHistory(odometerVal.toFloat())
             } ?: run {
                 binding.odometer.visibility = View.INVISIBLE
             }

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -1137,7 +1137,11 @@ class DashFragment : Fragment() {
             }
 
             efficiencyCalculator.getEfficiencyText(uiSpeedUnitsMPH, power)?.let { efficiencyText ->
-                if (!prefs.getBooleanPref(Constants.hideEfficiency)) {
+                if (!prefs.getBooleanPref(Constants.hideEfficiency) && gearState !in setOf(
+                        Constants.gearInvalid,
+                        Constants.gearPark
+                    )
+                ) {
                     binding.efficiency.text = efficiencyText
                     binding.efficiency.visibility = View.VISIBLE
                 } else {

--- a/android/app/src/main/java/app/candash/cluster/EfficiencyCalculator.kt
+++ b/android/app/src/main/java/app/candash/cluster/EfficiencyCalculator.kt
@@ -1,0 +1,197 @@
+package app.candash.cluster
+
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+class EfficiencyCalculator(
+    private val viewModel: DashViewModel,
+    private val prefs: SharedPreferences
+) {
+    private val gson = Gson()
+
+    // these triples contain (odometerKm, kwhDischarge, kwhCharge)
+    private var kwhHistory = mutableListOf<Triple<Float, Float, Float>>()
+    private var parkedKwhHistory = mutableListOf<Triple<Float, Float, Float>>()
+    private var parkedStartKwh: Pair<Float, Float>? = null
+    private val tripleFloatListType =
+        object : TypeToken<MutableList<Triple<Float, Float, Float>>>() {}.type
+
+    private val Float.miToKm: Float
+        get() = (this / .621371).toFloat()
+    private val Float.kmToMi: Float
+        get() = (this * .621371).toFloat()
+
+    fun changeLookBack(inMiles: Boolean): String {
+        val old = prefs.getPref(Constants.efficiencyLookBack)
+        val options = if (inMiles) {
+            listOf(0f, 5f.miToKm, 15f.miToKm, 30f.miToKm)
+        } else {
+            listOf(0f, 10f, 25f, 50f)
+        }
+        val index = (options.indexOf(old) + 1) % options.size
+        prefs.setPref(Constants.efficiencyLookBack, options[index])
+
+        return if (inMiles) {
+            "Last %.0f miles".format(options[index].kmToMi)
+        } else {
+            "Last %.0f kilometers".format(options[index])
+        }
+    }
+
+    fun updateKwhHistory(odoKm: Float) {
+        loadHistoryFromPrefs()
+        val kwhDischargeTotal = viewModel.getValue(Constants.kwhDischargeTotal)
+        val kwhChargeTotal = viewModel.getValue(Constants.kwhChargeTotal)
+        if (kwhDischargeTotal == null || kwhChargeTotal == null) {
+            return
+        }
+        updateParkedHistory(odoKm, kwhDischargeTotal, kwhChargeTotal)
+        updateHistory(odoKm, kwhDischargeTotal, kwhChargeTotal)
+    }
+
+    fun getEfficiencyText(inMiles: Boolean, power: Float): String? {
+        val lookBackKm = prefs.getPref(Constants.efficiencyLookBack)
+        return if (lookBackKm == 0f) {
+            getInstantEfficiencyText(inMiles, power)
+        } else {
+            getRecentEfficiencyText(inMiles, lookBackKm)
+        }
+    }
+
+    private fun getInstantEfficiencyText(inMiles: Boolean, power: Float): String? {
+        val speed = viewModel.getValue(Constants.uiSpeed) ?: return null
+        val instantEfficiency = power / speed / 1000f
+        return if (inMiles) {
+            "%.2f kWh/mi".format(instantEfficiency)
+        } else {
+            "%.2f kWh/km".format(instantEfficiency)
+        }
+    }
+
+    private fun getRecentEfficiencyText(inMiles: Boolean, lookBackKm: Float): String? {
+        val newOdo = viewModel.getValue(Constants.odometer)
+        val newDischarge = viewModel.getValue(Constants.kwhDischargeTotal)
+        val newCharge = viewModel.getValue(Constants.kwhChargeTotal)
+        if (newOdo == null || newDischarge == null || newCharge == null) {
+            return null
+        }
+        val targetKm = newOdo - lookBackKm
+        val oldKwhTriple = kwhHistory.lastOrNull { it.first <= targetKm }
+            ?: return getCalculatingText(inMiles, lookBackKm, newOdo)
+
+        val odoDelta = newOdo - oldKwhTriple.first
+        var dischargeDelta = newDischarge - oldKwhTriple.second
+        var chargeDelta = newCharge - oldKwhTriple.third
+        // Subtract parked consumption/charges
+        for (parkedTriple in parkedKwhHistory.filter { it.first >= targetKm }) {
+            dischargeDelta -= parkedTriple.second
+            chargeDelta -= parkedTriple.third
+        }
+        val consumedWh = (dischargeDelta - chargeDelta) * 1000f
+        return if (inMiles) {
+            "%.0f Wh/mi".format((consumedWh / odoDelta.kmToMi))
+        } else {
+            "%.0f Wh/km".format(consumedWh / odoDelta)
+        }
+    }
+
+    private fun getCalculatingText(inMiles: Boolean, lookBackKm: Float, odo: Float): String {
+        if (kwhHistory.size > 0) {
+            val distanceKm = odo - kwhHistory.first().first
+            // Using toInt as a floor rounding
+            return if (inMiles) {
+                "(%d of %d mi)".format(
+                    distanceKm.kmToMi.toInt(),
+                    lookBackKm.kmToMi.toInt()
+                )
+            } else {
+                "(%d of %d km)".format(
+                    distanceKm.toInt(),
+                    lookBackKm.toInt()
+                )
+            }
+        } else {
+            return "(calculating)"
+        }
+    }
+
+    private fun saveHistoryToPrefs() {
+        prefs.setStringPref(Constants.kwhHistory, gson.toJson(kwhHistory))
+        prefs.setStringPref(Constants.parkedKwhHistory, gson.toJson(parkedKwhHistory))
+    }
+
+    private fun loadHistoryFromPrefs() {
+        if (kwhHistory.isEmpty() && prefs.getStringPref(Constants.kwhHistory) != null) {
+            kwhHistory =
+                gson.fromJson(prefs.getStringPref(Constants.kwhHistory), tripleFloatListType)
+        }
+        if (parkedKwhHistory.isEmpty() && prefs.getStringPref(Constants.parkedKwhHistory) != null) {
+            parkedKwhHistory =
+                gson.fromJson(prefs.getStringPref(Constants.parkedKwhHistory), tripleFloatListType)
+        }
+        if (parkedStartKwh == null && prefs.getPref(Constants.parkedStartKwhDischarge) > 0) {
+            parkedStartKwh = Pair(
+                prefs.getPref(Constants.parkedStartKwhDischarge),
+                prefs.getPref(Constants.parkedStartKwhCharge)
+            )
+        }
+    }
+
+    private fun updateParkedHistory(odo: Float, discharge: Float, charge: Float) {
+        val gear = viewModel.getValue(Constants.gearSelected) ?: Constants.gearInvalid
+        // Edge from Drive to Park
+        if (gear in setOf(Constants.gearPark, Constants.gearInvalid) && parkedStartKwh == null) {
+            parkedStartKwh = Pair(discharge, charge)
+            prefs.setPref(Constants.parkedStartKwhDischarge, discharge)
+            prefs.setPref(Constants.parkedStartKwhCharge, charge)
+        }
+
+        // Edge from Park to Drive
+        if (gear !in setOf(Constants.gearPark, Constants.gearInvalid) && parkedStartKwh != null) {
+            parkedKwhHistory.add(
+                Triple(
+                    odo,
+                    discharge - parkedStartKwh!!.first,
+                    charge - parkedStartKwh!!.second
+                )
+            )
+            while (parkedKwhHistory.firstOrNull { it.first < odo - 51f } != null) {
+                parkedKwhHistory.removeFirst()
+            }
+            saveHistoryToPrefs()
+            parkedStartKwh = null
+            prefs.setPref(Constants.parkedStartKwhDischarge, 0f)
+            prefs.setPref(Constants.parkedStartKwhCharge, 0f)
+        }
+    }
+
+    private fun updateHistory(odo: Float, discharge: Float, charge: Float) {
+        val histEndOdo = kwhHistory.lastOrNull()?.first ?: 0f
+        if (odo - histEndOdo >= 1.0 || odo - histEndOdo < 0f) {
+            // We're missing too much data, reset
+            kwhHistory.clear()
+            kwhHistory.add(
+                Triple(
+                    odo,
+                    discharge,
+                    charge
+                )
+            )
+        } else if (odo - histEndOdo >= 0.1) {
+            kwhHistory.add(
+                Triple(
+                    odo,
+                    discharge,
+                    charge
+                )
+            )
+        } else {
+            return
+        }
+        while (kwhHistory.firstOrNull { it.first < odo - 51f } != null) {
+            kwhHistory.removeFirst()
+        }
+        saveHistoryToPrefs()
+    }
+}

--- a/android/app/src/main/java/app/candash/cluster/EfficiencyCalculator.kt
+++ b/android/app/src/main/java/app/candash/cluster/EfficiencyCalculator.kt
@@ -62,7 +62,7 @@ class EfficiencyCalculator(
     }
 
     private fun updateParkedHistory(odo: Float, discharge: Float, charge: Float) {
-        val gear = viewModel.getValue(Constants.gearSelected) ?: Constants.gearInvalid
+        val gear = viewModel.getValue(Constants.gearSelected)?.toInt() ?: Constants.gearInvalid
         // Switching from D/R/N to Park
         if (gear in setOf(Constants.gearPark, Constants.gearInvalid) && parkedStartKwh == null) {
             parkedStartKwh = Pair(discharge, charge)
@@ -79,10 +79,10 @@ class EfficiencyCalculator(
                     charge - parkedStartKwh!!.second
                 )
             )
+            parkedStartKwh = null
             while (parkedKwhHistory.firstOrNull { it.first < odo - 51f } != null) {
                 parkedKwhHistory.removeFirst()
             }
-            parkedStartKwh = null
             saveHistoryToPrefs()
             return
         }

--- a/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
@@ -55,7 +55,7 @@ class SettingsFragment() : Fragment() {
         binding.showSpeedLimit.isChecked = !prefs.getBooleanPref(Constants.hideSpeedLimit)
         // This is not inverted, because defaulting to blank display makes the app appear broken on first launch
         binding.blankDisplaySync.isChecked = prefs.getBooleanPref(Constants.blankDisplaySync)
-        binding.showInstefficiency.isChecked = !prefs.getBooleanPref(Constants.hideInstEfficiency)
+        binding.showEfficiency.isChecked = !prefs.getBooleanPref(Constants.hideEfficiency)
         if (prefs.getBooleanPref(Constants.tempInF)) {
             binding.tempUnitF.isChecked = true
         } else {
@@ -108,10 +108,10 @@ class SettingsFragment() : Fragment() {
             prefs.setBooleanPref(Constants.blankDisplaySync, false)
         }
 
-        if (binding.showInstefficiency.isChecked) {
-            prefs.setBooleanPref(Constants.hideInstEfficiency, false)
+        if (binding.showEfficiency.isChecked) {
+            prefs.setBooleanPref(Constants.hideEfficiency, false)
         } else {
-            prefs.setBooleanPref(Constants.hideInstEfficiency, true)
+            prefs.setBooleanPref(Constants.hideEfficiency, true)
         }
         when (binding.tempUnits.checkedRadioButtonId) {
             R.id.tempUnitC -> prefs.setBooleanPref(Constants.tempInF, false)

--- a/android/app/src/main/java/app/candash/cluster/SharedPreferencesExtensions.kt
+++ b/android/app/src/main/java/app/candash/cluster/SharedPreferencesExtensions.kt
@@ -16,6 +16,13 @@ fun SharedPreferences.setBooleanPref(name: String, value: Boolean) {
     }
 }
 
+fun SharedPreferences.setStringPref(name: String, value: String) {
+    with(this.edit()) {
+        putString(name, value)
+        apply()
+    }
+}
+
 fun SharedPreferences.prefContains(name: String): Boolean {
     return this.contains(name)
 }
@@ -26,4 +33,8 @@ fun SharedPreferences.getPref(name: String): Float {
 
 fun SharedPreferences.getBooleanPref(name: String): Boolean {
     return this.getBoolean(name, false)
+}
+
+fun SharedPreferences.getStringPref(name: String): String? {
+    return this.getString(name, null)
 }

--- a/android/app/src/main/res/layout/fragment_dash.xml
+++ b/android/app/src/main/res/layout/fragment_dash.xml
@@ -295,17 +295,17 @@
         app:layout_constraintTop_toBottomOf="@+id/rearbraketempunits" />
 
     <ImageView
-        android:id="@+id/telltale_brake_hold"
-        android:layout_width="35dp"
-        android:layout_height="35dp"
+        android:id="@+id/speedo_brake_hold"
+        android:layout_width="140dp"
+        android:layout_height="150dp"
+        android:paddingTop="18dp"
 
         android:src="@drawable/ic_brake_hold"
         android:visibility="invisible"
-        app:layout_constraintBottom_toTopOf="@+id/power_bar"
+        app:layout_constraintTop_toTopOf="@+id/speed"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/rearbraketempunits"
-        tools:visibility="visible" />
+        app:layout_constraintBottom_toBottomOf="@+id/speed" />
 
     <ImageView
         android:id="@+id/telltale_brake_park_fault"
@@ -1607,7 +1607,7 @@
 
         />
     <TextView
-        android:id="@+id/instefficiency"
+        android:id="@+id/efficiency"
         android:layout_height="30dp"
         android:layout_width="0dp"
         android:layout_marginBottom="0dp"
@@ -1797,18 +1797,21 @@
         tools:visibility="gone" />
 
     <TextView
-        android:id="@+id/blackoutToast"
+        android:id="@+id/infoToast"
         android:drawablePadding="5dp"
         android:layout_width="300dp"
         android:layout_height="60dp"
         android:fontFamily="@font/interbold"
         android:textColor="#cccccc"
-        android:visibility="gone"
+        android:visibility="invisible"
         android:background="@drawable/rounded_corner"
         android:gravity="center|center_vertical"
-        android:text="Display sleeping with car.\nLong-press left edge for settings."
+        android:text="Some info goes here"
         android:textAlignment="center"
-        android:textSize="15dp"
+        app:autoSizeMinTextSize="15dp"
+        app:autoSizeMaxTextSize="25dp"
+        app:autoSizeStepGranularity="1dp"
+        app:autoSizeTextType="uniform"
         android:paddingLeft="10dp"
         android:paddingRight="10dp"
         android:paddingTop="5dp"

--- a/android/app/src/main/res/layout/fragment_settings.xml
+++ b/android/app/src/main/res/layout/fragment_settings.xml
@@ -123,21 +123,23 @@
         app:layout_constraintTop_toBottomOf="@id/showBs" />
 
     <CheckBox
+        android:id="@+id/showEfficiency"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:text="Show Driving Efficiency"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
+        app:layout_constraintTop_toBottomOf="@id/showSpeedLimit" />
+
+    <CheckBox
         android:id="@+id/blankDisplaySync"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
         android:text="Blackout Screen w/ Center Display"
         app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
-        app:layout_constraintTop_toBottomOf="@id/showSpeedLimit" />
-    <CheckBox
-        android:id="@+id/showInstefficiency"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="10dp"
-        android:text="Show Instantaneous Efficiency"
-        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
-        app:layout_constraintTop_toBottomOf="@id/blankDisplaySync" />
+        app:layout_constraintTop_toBottomOf="@id/showEfficiency" />
+
     <TextView
         android:id="@+id/blankDisplayHint"
         android:layout_width="wrap_content"
@@ -146,7 +148,7 @@
         android:text="Long-press left side of screen to return\nto settings while display is off.\nRecommended only with OLED screens."
         android:textSize="12dp"
         app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
-        app:layout_constraintTop_toBottomOf="@id/showInstefficiency" />
+        app:layout_constraintTop_toBottomOf="@id/blankDisplaySync" />
 
 
     <androidx.constraintlayout.widget.Guideline


### PR DESCRIPTION
Allows for tapping the efficiency view to change between Last 5, 15, 30 miles, or 0 (instant). For KM the options are 10, 25, 50, and 0 km.

The instant efficiency is formatted to kWh with 2 decimal places as that value changes extremely rapidly and gets quite large. For historical efficiency it uses whole number Wh units to match the ICE.

The calculation is fairly close to the ICE, it updates faster so it never perfectly matches. The calculation discards any parked consumption/charging, and the history is retained even across app restarts or updates to newer versions.

Here's a video showing the 5 mile range, pending 15 and 30 mile ranges, and instant efficiency (including negative and infinity).
Note there is flickering of the 5 mile range that is only an artifact of how I am playing back logged can data, and does not appear in-car.
https://photos.app.goo.gl/qJzE7wvxaVwTkSWJA

To make room for the efficiency value to remain on-screen while stopped, the brake hold telltale was moved to replace the speedo when active, to match the behavior of US market cars. For simplicity other markets will share this same behavior in Candash.

Video of the updated brake hold:
https://photos.app.goo.gl/29PefauszsgUs3WC9

Tested in-car with both miles and km units, instant efficiency, and each historical option for each unit. Ensured that history wasn't lost while restarting.