### PR TITLE
Improve AP and blindspot warning animations

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 
 class MockCANService : CANService {
-    private val MS_BETWEEN_REQUESTS = 2_000L
+    private val MS_BETWEEN_REQUESTS = 3_000L
     private val carStateFlow = MutableStateFlow(CarState())
     private val pandaContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     private var shutdown = false
@@ -74,7 +74,7 @@ class MockCANService : CANService {
             CarState(mutableMapOf(
                 Constants.autopilotState to 3f,
                 Constants.isSunUp to 1f,
-                Constants.autopilotHands to 1f,
+                Constants.autopilotHands to 3f,
                 Constants.driveConfig to 0f,
                 Constants.gearSelected to Constants.gearDrive.toFloat(),
                 Constants.stateOfCharge to 70f,
@@ -96,6 +96,8 @@ class MockCANService : CANService {
             CarState(mutableMapOf(
                 Constants.autopilotState to 1f,
                 Constants.isSunUp to 1f,
+                Constants.autopilotHands to 1f,
+                Constants.blindSpotLeft to 1f,
                 Constants.driveConfig to 1f,
                 Constants.stateOfCharge to 70f,
                 Constants.battAmps to -10f,
@@ -113,6 +115,7 @@ class MockCANService : CANService {
             CarState(mutableMapOf(
                 Constants.autopilotState to 1f,
                 Constants.isSunUp to 1f,
+                Constants.blindSpotLeft to 0f,
                 Constants.uiSpeed to 65.0f,
                 Constants.uiSpeedUnits to 0f,
                 Constants.frontLeftDoorState to 1f,

--- a/android/app/src/main/res/layout/fragment_dash.xml
+++ b/android/app/src/main/res/layout/fragment_dash.xml
@@ -610,56 +610,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-
-    <TextView
-        android:id="@+id/BSWarningLeft"
-        android:drawableLeft="@drawable/ic_bsl2"
-        android:drawablePadding="5dp"
-        android:layout_width="300dp"
-        android:layout_height="45dp"
-        android:visibility="gone"
-        android:fontFamily="@font/interbold"
-        android:textColor="#cccccc"
-        android:background="@drawable/rounded_corner"
-        android:gravity="center|center_vertical"
-        android:text="Check blind spot"
-        android:textAlignment="center"
-        android:textSize="20dp"
-        android:layout_marginTop="24dp"
-        android:paddingLeft="25dp"
-        android:paddingRight="30dp"
-        android:paddingTop="5dp"
-        android:paddingBottom="5dp"
-
-
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"/>
-    <TextView
-        android:id="@+id/BSWarningRight"
-        android:drawableRight="@drawable/ic_bsr2"
-        android:drawablePadding="15dp"
-        android:layout_width="300dp"
-        android:layout_height="45dp"
-        android:visibility="gone"
-        android:fontFamily="@font/interbold"
-        android:textColor="#cccccc"
-        android:background="@drawable/rounded_corner"
-        android:gravity="center|center_vertical"
-        android:text="Check blind spot"
-        android:textAlignment="center"
-        android:textSize="20dp"
-        android:layout_marginTop="24dp"
-        android:paddingLeft="30dp"
-        android:paddingRight="10dp"
-        android:paddingTop="5dp"
-        android:paddingBottom="5dp"
-
-
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"/>
-
     <TextView
         android:id="@+id/batterypercent"
         android:layout_width="wrap_content"
@@ -1733,6 +1683,62 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintWidth_percent=".2"
         tools:text="0 W" />
+
+    <ImageView
+        android:id="@+id/warning_gradient_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:visibility="gone" />
+
+    <TextView
+        android:id="@+id/BSWarningLeft"
+        android:drawableLeft="@drawable/ic_bsl2"
+        android:drawablePadding="5dp"
+        android:layout_width="300dp"
+        android:layout_height="45dp"
+        android:visibility="gone"
+        android:fontFamily="@font/interbold"
+        android:textColor="#cccccc"
+        android:background="@drawable/rounded_corner"
+        android:gravity="center|center_vertical"
+        android:text="Check blind spot"
+        android:textAlignment="center"
+        android:textSize="20dp"
+        android:layout_marginTop="24dp"
+        android:paddingLeft="25dp"
+        android:paddingRight="30dp"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp"
+
+
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"/>
+
+    <TextView
+        android:id="@+id/BSWarningRight"
+        android:drawableRight="@drawable/ic_bsr2"
+        android:drawablePadding="15dp"
+        android:layout_width="300dp"
+        android:layout_height="45dp"
+        android:visibility="gone"
+        android:fontFamily="@font/interbold"
+        android:textColor="#cccccc"
+        android:background="@drawable/rounded_corner"
+        android:gravity="center|center_vertical"
+        android:text="Check blind spot"
+        android:textAlignment="center"
+        android:textSize="20dp"
+        android:layout_marginTop="24dp"
+        android:paddingLeft="30dp"
+        android:paddingRight="10dp"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp"
+
+
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"/>
 
     <TextView
         android:id="@+id/APWarning"

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -31,4 +31,5 @@
     <color name="telltale_red">#ff3a3a</color>
     <color name="telltale_blue">#006cff</color>
     <color name="telltale_inactive">#909090</color>
+    <color name="transparent_blank">#00000000</color>
 </resources>


### PR DESCRIPTION
(in draft while soak testing in-car)

- No longer uses background for AP/blindspot warnings, freeing up ability to add background artwork if desired
- Adjusting timing of the AP flashes to (somewhat) sync up with the ICE display flashing
- Uses transparent gradient over top of gauges to match ICE display
- Blindspot gradient is directional left/right depending on blindspot side
