### PR TITLE
Create horizontal constraints helper for easily mirroring view placement

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
+++ b/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
@@ -123,6 +123,7 @@ class CANSignalHelper {
         insertCANSignal(Constants.battBrickMin, Constants.vehicleBus, Hex(0x332), 24, 8, .5f, -40f, 2, 0)
         insertCANSignal(Constants.driveConfig, Constants.vehicleBus, Hex(0x7FF), 10, 1, 1f, 0f, 8, 1)
         insertCANSignal(Constants.mapRegion, Constants.vehicleBus, Hex(0x7FF), 8, 4, 1f, 0f, 8, 3)
+        insertCANSignal(Constants.driverOrientation, Constants.vehicleBus, Hex(0x211), 40, 3, 1f, 0f, sna=7f)
         insertCANSignal(Constants.frontTemp, Constants.vehicleBus, Hex(0x396), 24, 8, 1f, -40f)
         insertCANSignal(Constants.rearTemp, Constants.vehicleBus, Hex(0x395), 24, 8, 1f, -40f)
         insertCANSignal(Constants.coolantFlow, Constants.vehicleBus, Hex(0x241), 22, 9, .1f, 0f)

--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -70,6 +70,7 @@ object Constants {
     const val mapME = 8f
     const val mapHK = 9f
     const val mapMO = 10f
+    const val driverOrientation = "driverOrientation"
     const val awd = 1f
     const val rwd = 0f
     const val frontTemp = "frontTemp"

--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -146,6 +146,8 @@ object Constants {
     const val torqueInLbfFt = "torqueInLbfFt"
     const val hideEfficiency = "hideEfficiency"
     const val efficiencyLookBack = "efficiencyLookBack"
+    const val detectedRHD = "detectedRHD"
+    const val forceRHD = "forceRHD"
 
     // For efficiency history in prefs
     const val kwhHistory = "kwhHistory"

--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -48,7 +48,6 @@ class MockCANService : CANService {
     private fun mockCarStates() : List<CarState> =
         listOf(
             CarState(mutableMapOf(
-                Constants.driverOrientation to 1f,
                 Constants.autopilotState to 2f,
                 Constants.isSunUp to 1f,
                 Constants.autopilotHands to 1f,

--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -48,7 +48,8 @@ class MockCANService : CANService {
     private fun mockCarStates() : List<CarState> =
         listOf(
             CarState(mutableMapOf(
-                Constants.autopilotState to 1f,
+                Constants.driverOrientation to 1f,
+                Constants.autopilotState to 2f,
                 Constants.isSunUp to 1f,
                 Constants.autopilotHands to 1f,
                 Constants.driveConfig to 0f,

--- a/android/app/src/main/res/layout/fragment_dash.xml
+++ b/android/app/src/main/res/layout/fragment_dash.xml
@@ -665,7 +665,7 @@
         android:gravity="center|center"
         android:paddingTop="0dp"
         android:src="@drawable/ic_batt_charging"
-        android:visibility="visible"
+        android:visibility="gone"
         app:layout_constraintEnd_toStartOf="@+id/batterypercent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -677,9 +677,9 @@
         android:gravity="center|center"
         android:paddingTop="0dp"
         android:src="@drawable/ic_batt_heating"
+        android:visibility="gone"
         app:layout_constraintEnd_toStartOf="@+id/batt_charge"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/battery"
@@ -729,7 +729,7 @@
 
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent=".5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/modely"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent=".4" />
 
@@ -742,7 +742,7 @@
 
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent=".5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/modely"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent=".4" />
 
@@ -755,7 +755,7 @@
 
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent=".5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/modely"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent=".4" />
 
@@ -768,7 +768,7 @@
 
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent=".5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/modely"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent=".4" />
 
@@ -782,7 +782,7 @@
 
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent=".5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/modely"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent=".4" />
 
@@ -795,7 +795,7 @@
 
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent=".5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/modely"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent=".4" />
 

--- a/android/app/src/main/res/layout/fragment_dash.xml
+++ b/android/app/src/main/res/layout/fragment_dash.xml
@@ -125,22 +125,9 @@
         android:src="@drawable/ic_autopilot"
         android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="@+id/PRND"
-        app:layout_constraintStart_toStartOf="@+id/autopilot_inactive"
-        app:layout_constraintTop_toTopOf="@+id/PRND"
-        tools:visibility="visible" />
-
-    <ImageView
-        android:id="@+id/autopilot_inactive"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
-        android:gravity="center"
-
-        android:src="@drawable/ic_autopilot_inactive"
-        android:visibility="invisible"
-        app:layout_constraintBottom_toBottomOf="@+id/PRND"
         app:layout_constraintStart_toEndOf="@+id/PRND"
         app:layout_constraintTop_toTopOf="@+id/PRND"
-        tools:visibility="invisible" />
+        tools:visibility="visible" />
 
     <!--    <ImageView-->
     <!--        android:id="@+id/autopilot_max_speed"-->
@@ -621,32 +608,14 @@
         android:fontFamily="@font/interbold"
         android:gravity="center|center_vertical"
         android:paddingLeft="10dp"
+        android:paddingRight="10dp"
         android:text="P  R  N  D"
         android:textAlignment="center"
         android:textColor="@color/prnd_not_selected"
         android:textSize="20dp"
 
-
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/batterypercent"
-        android:layout_width="wrap_content"
-        android:layout_height="26dp"
-        android:layout_marginEnd="8dp"
-        android:fontFamily="@font/interbold"
-
-        android:gravity="end|top"
-        android:paddingRight="5dp"
-        android:paddingBottom="0dp"
-        android:text="377 km"
-
-
-        android:textSize="20dp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@id/deadbattery"
-        app:layout_constraintEnd_toStartOf="@id/deadbattery" />
 
     <TextView
         android:id="@+id/odometer"
@@ -665,20 +634,28 @@
         android:visibility="gone"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toBottomOf="@+id/PRND"
-        app:layout_constraintStart_toEndOf="@+id/PRND"
+        app:layout_constraintStart_toEndOf="@+id/autopilot"
         app:layout_constraintTop_toTopOf="@+id/PRND" />
 
-    <ImageView
-        android:id="@+id/deadbattery"
-        android:layout_width="70dp"
-        android:layout_height="25dp"
-        android:layout_marginTop="16.5dp"
-        android:gravity="center|center"
-        android:paddingTop="0dp"
-        android:paddingRight="20dp"
-        android:src="@drawable/ic_deadbattery"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <TextView
+        android:id="@+id/batterypercent"
+        android:layout_width="wrap_content"
+        android:layout_height="26dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:fontFamily="@font/interbold"
+
+        android:gravity="end|top"
+        android:paddingLeft="5dp"
+        android:paddingRight="5dp"
+        android:paddingBottom="0dp"
+        android:text="377 km"
+
+
+        android:textSize="20dp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toBottomOf="@id/battery"
+        app:layout_constraintEnd_toStartOf="@id/battery" />
 
     <ImageView
         android:id="@+id/batt_charge"
@@ -688,7 +665,7 @@
         android:gravity="center|center"
         android:paddingTop="0dp"
         android:src="@drawable/ic_batt_charging"
-        android:visibility="gone"
+        android:visibility="visible"
         app:layout_constraintEnd_toStartOf="@+id/batterypercent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -697,25 +674,35 @@
         android:layout_width="25dp"
         android:layout_height="25dp"
         android:layout_marginTop="16.5dp"
-        android:layout_marginEnd="8dp"
         android:gravity="center|center"
         android:paddingTop="0dp"
         android:src="@drawable/ic_batt_heating"
-        android:visibility="gone"
         app:layout_constraintEnd_toStartOf="@+id/batt_charge"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
-    <app.candash.cluster.BatteryGauge
-        android:id="@+id/fullbattery"
-        android:layout_width="70dp"
+    <ImageView
+        android:id="@+id/battery"
+        android:layout_width="50dp"
         android:layout_height="25dp"
         android:layout_marginTop="16.5dp"
         android:gravity="center|center"
         android:paddingTop="0dp"
-        android:paddingRight="20dp"
-        android:src="@drawable/ic_fullbattery"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:src="@drawable/ic_deadbattery"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <app.candash.cluster.BatteryGauge
+        android:id="@+id/batteryOverlay"
+        android:layout_width="50dp"
+        android:layout_height="25dp"
+        android:layout_marginTop="16.5dp"
+        android:gravity="center|center"
+        android:paddingTop="0dp"
+        android:src="@drawable/ic_fullbattery"
+        app:layout_constraintEnd_toEndOf="@id/battery"
         app:layout_constraintTop_toTopOf="parent" />
 
 


### PR DESCRIPTION
This updates the layout to reverse the order of the topmost views (PRND, AP, battery stuff) when the vehicle is a RHD market vehicle. It also moves the doors views to the right side.

A bit of cleanup was also done on the battery view names and the autopilot icon logic.

Tested with mock server setting driverOrientation to 2f