### PR TITLE
Decrease max filter count for s3xy commander compatibility

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
+++ b/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
@@ -6,7 +6,7 @@ class CANSignalHelper {
     private val TAG = CANSignalHelper::class.java.simpleName
 
     companion object {
-        const val MAX_FILTERS = 43
+        const val MAX_FILTERS = 42
 
         const val CLEAR_FILTERS_BYTE : Byte = 0x18
         const val ADD_FILTERS_BYTE : Byte = 0x0F


### PR DESCRIPTION
We discovered that the last frame id from filter request is ignored by s3xy commander, which in the last couple of versions as been the gear selected signal, and commander users noted that the PRND has disappeared. Currently the filter payload is up to 130 bytes, but I suspect (not verified) the commander expects a max 128 bytes as it's a nice round number.

This changes the max filter payload to 127 bytes (42*3+1)