### PR TITLE
Long press to reset min-max power and more

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -346,20 +346,30 @@ class DashFragment : Fragment() {
         setGaugeVisibility()
         setLayoutOrder()
 
-        binding.minpower.setOnClickListener {
+        binding.minpower.setOnLongClickListener {
             prefs.setPref("minPower", 0f)
+            binding.infoToast.text = "Reset min power value"
+            binding.infoToast.visible = true
+            binding.infoToast.startAnimation(fadeOut(5000))
+            return@setOnLongClickListener true
         }
-        binding.maxpower.setOnClickListener {
+        binding.maxpower.setOnLongClickListener {
             prefs.setPref("maxPower", 0f)
+            binding.infoToast.text = "Reset max power value"
+            binding.infoToast.visible = true
+            binding.infoToast.startAnimation(fadeOut(5000))
+            return@setOnLongClickListener true
         }
         binding.root.setOnLongClickListener {
-            viewModel.switchToInfoFragment()
             viewModel.switchToInfoFragment()
             return@setOnLongClickListener true
         }
         binding.batterypercent.setOnClickListener {
             prefs.setBooleanPref(Constants.showBattRange, !prefs.getBooleanPref(Constants.showBattRange))
             processBattery()
+            binding.infoToast.text = if (prefs.getBooleanPref(Constants.showBattRange)) "Showing battery range" else "Showing battery SOC"
+            binding.infoToast.visible = true
+            binding.infoToast.startAnimation(fadeOut(5000))
         }
         binding.unit.setOnClickListener {
             if (prefs.getPref(Constants.gaugeMode) < Constants.showFullGauges) {
@@ -368,6 +378,14 @@ class DashFragment : Fragment() {
                 prefs.setPref(Constants.gaugeMode, Constants.showSimpleGauges)
             }
             setGaugeVisibility()
+            binding.infoToast.text = when (prefs.getPref(Constants.gaugeMode)) {
+                Constants.showSimpleGauges -> "Showing simple gauges"
+                Constants.showRegularGauges -> "Showing regular gauges"
+                Constants.showFullGauges -> "Showing full gauges"
+                else -> "Unknown gauge selection"
+            }
+            binding.infoToast.visible = true
+            binding.infoToast.startAnimation(fadeOut(5000))
         }
 
         binding.power.setOnClickListener {
@@ -376,17 +394,26 @@ class DashFragment : Fragment() {
             } else {
                 prefs.setPref(Constants.powerUnits, Constants.powerUnitKw)
             }
+            binding.infoToast.text = "Power unit:" + unitConverter.prefPowerUnit().tag
+            binding.infoToast.visible = true
+            binding.infoToast.startAnimation(fadeOut(5000))
         }
 
         binding.PRND.setOnLongClickListener {
             prefs.setBooleanPref(Constants.forceRHD, !prefs.getBooleanPref(Constants.forceRHD))
             setLayoutOrder()
+            binding.infoToast.text = if (prefs.getBooleanPref(Constants.forceRHD)) "Force right-hand drive" else "Auto right-hand drive"
+            binding.infoToast.visible = true
+            binding.infoToast.startAnimation(fadeOut(5000))
             return@setOnLongClickListener true
         }
 
         binding.speed.setOnLongClickListener {
             prefs.setBooleanPref(Constants.forceNightMode, !prefs.getBooleanPref(Constants.forceNightMode))
             setColors()
+            binding.infoToast.text = if (prefs.getBooleanPref(Constants.forceNightMode)) "Force dark mode" else "Auto dark mode"
+            binding.infoToast.visible = true
+            binding.infoToast.startAnimation(fadeOut(5000))
             return@setOnLongClickListener true
         }
 

--- a/android/app/src/main/java/app/candash/cluster/EfficiencyCalculator.kt
+++ b/android/app/src/main/java/app/candash/cluster/EfficiencyCalculator.kt
@@ -114,7 +114,11 @@ class EfficiencyCalculator(
     }
 
     private fun getInstantEfficiencyText(inMiles: Boolean, power: Float): String? {
-        val speed = viewModel.carState[SName.uiSpeed] ?: return null
+        val speed = viewModel.carState[SName.uiSpeed] ?: 0f
+        // If speed is 0 (or null) return to prevent "infinity kWh/mi"
+        if (speed == 0f) {
+            return null
+        }
         val instantEfficiency = power / speed / 1000f
         return if (inMiles) {
             "%.2f kWh/mi".format(instantEfficiency)


### PR DESCRIPTION
A few minor tweaks:
- require a long-press to reset min/max power values (instead of short press)
- show an info toast for any UI tap action describing what that action just did
- hide the instant efficiency text if speed is 0, to prevent "infinity kWh/mi"