### PR TITLE
Fix partially inverted display sync pref

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/Constants.kt
+++ b/android/app/src/main/java/app/candash/cluster/Constants.kt
@@ -22,7 +22,7 @@ object Constants {
     const val hideOdometer = "hideOdometer"
     const val hideBs = "hideBs"
     const val hideSpeedLimit = "hideSpeedLimit"
-    const val blankDisplaySync = "blankDisplaySync"
+    const val disableDisplaySync = "disableDisplaySync"
     const val tempInF = "tempInF"
     const val partyTempInF = "partyTempInF"
     const val powerUnits = "powerUnits"

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -1069,8 +1069,7 @@ class DashFragment : Fragment() {
             // Don't change the visibility if we lost the signal, maintain the last state
             return
         }
-        // because all booleanprefs default to false, we invert the pref and setting. blankDisplaySync == false is enabled
-        if (!prefs.getBooleanPref(Constants.blankDisplaySync)
+        if (!prefs.getBooleanPref(Constants.disableDisplaySync)
             && gearState() in setOf(SVal.gearPark, SVal.gearInvalid)
             && viewModel.carState[SName.displayOn] == 0f
         ) {

--- a/android/app/src/main/java/app/candash/cluster/FullscreenActivity.kt
+++ b/android/app/src/main/java/app/candash/cluster/FullscreenActivity.kt
@@ -82,7 +82,7 @@ class FullscreenActivity : AppCompatActivity() {
             }
             val lowBattery: Boolean = batteryPct == null || batteryPct <= 20f
 
-            if (isPlugged || (!lowBattery && prefs.getBooleanPref(Constants.blankDisplaySync))) {
+            if (isPlugged || (!lowBattery && !prefs.getBooleanPref(Constants.disableDisplaySync))) {
                 this@FullscreenActivity.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
                 //Log.d(TAG, "keep_screen_on")
             } else {

--- a/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
@@ -275,7 +275,7 @@ class PartyFragment : Fragment() {
 
     private fun updateBlackout() {
         // the displayOn signal is always true in party mode, so instead we look at doors and butts
-        if (!prefs.getBooleanPref(Constants.blankDisplaySync)
+        if (!prefs.getBooleanPref(Constants.disableDisplaySync)
             && !anyDoorOpen()
             && viewModel.carState[SName.frontOccupancy] != 2f
         ) {

--- a/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
@@ -53,7 +53,7 @@ class SettingsFragment() : Fragment() {
         binding.showodo.isChecked = !prefs.getBooleanPref(Constants.hideOdometer)
         binding.showBs.isChecked = !prefs.getBooleanPref(Constants.hideBs)
         binding.showSpeedLimit.isChecked = !prefs.getBooleanPref(Constants.hideSpeedLimit)
-        binding.blankDisplaySync.isChecked = !prefs.getBooleanPref(Constants.blankDisplaySync)
+        binding.displaySync.isChecked = !prefs.getBooleanPref(Constants.disableDisplaySync)
         binding.showEfficiency.isChecked = !prefs.getBooleanPref(Constants.hideEfficiency)
         if (prefs.getBooleanPref(Constants.tempInF)) {
             binding.tempUnitF.isChecked = true
@@ -100,11 +100,10 @@ class SettingsFragment() : Fragment() {
         } else {
             prefs.setBooleanPref(Constants.hideSpeedLimit, true)
         }
-        // This is not inverted, because defaulting to blank display makes the app appear broken on first launch
-        if (binding.blankDisplaySync.isChecked) {
-            prefs.setBooleanPref(Constants.blankDisplaySync, false)
+        if (binding.displaySync.isChecked) {
+            prefs.setBooleanPref(Constants.disableDisplaySync, false)
         } else {
-            prefs.setBooleanPref(Constants.blankDisplaySync, true)
+            prefs.setBooleanPref(Constants.disableDisplaySync, true)
         }
 
         if (binding.showEfficiency.isChecked) {

--- a/android/app/src/main/res/layout/fragment_dash.xml
+++ b/android/app/src/main/res/layout/fragment_dash.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/night_background">
+    android:background="@color/day_background">
 
     <TextView
         android:id="@+id/speed"

--- a/android/app/src/main/res/layout/fragment_settings.xml
+++ b/android/app/src/main/res/layout/fragment_settings.xml
@@ -132,7 +132,7 @@
         app:layout_constraintTop_toBottomOf="@id/showSpeedLimit" />
 
     <CheckBox
-        android:id="@+id/blankDisplaySync"
+        android:id="@+id/displaySync"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
@@ -148,7 +148,7 @@
         android:text="Long-press left side of screen to return\nto settings while display is off.\nRecommended only with OLED screens."
         android:textSize="12dp"
         app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
-        app:layout_constraintTop_toBottomOf="@id/blankDisplaySync" />
+        app:layout_constraintTop_toBottomOf="@id/displaySync" />
 
 
     <androidx.constraintlayout.widget.Guideline


### PR DESCRIPTION
This fixes a bug from June where the display sync pref was inverted (partially), causing the behavior to be inverted in party mode, and also causing the screen-on behavior to be inverted (with display sync, it should keep the screen on even when not plugged in, until low battery).

The fix entails renaming the pref to be representative of what it does.

Renaming the pref ensures:
- that existing users have the pref reset to default rather than invert to the opposite of what they set (arguably worse)
- that if any usages of the old pref was missed, a build error would make it obvious.
- that the code reads logically by naming the pref a name which represents what it actually is, not the inverse.

### Tests:
- ensured the display blanking behavior matched the preference in both dash and party mode
- ensured the screen-on behavior matched the preference when the phone is not plugged in