### PR TITLE
Fix AHB logic for showing AHB standby telltale

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -1016,7 +1016,7 @@ class DashFragment : Fragment() {
             }
             binding.telltaleHb.visible = true
         } else {
-            if (viewModel.carState[SName.autoHighBeamEnabled] == 1f && viewModel.carState[SName.highBeamRequest] == SVal.highBeamAuto) {
+            if (viewModel.carState[SName.highBeamRequest] == SVal.highBeamAuto) {
                 binding.telltaleHb.setImageResource(R.drawable.ic_telltale_ahb_stdby)
                 binding.telltaleHb.visible = true
             } else {


### PR DESCRIPTION
A bug exists where if AHB (auto-highbeam) is disabled in the UI, while using autopilot the standby icon doesn't show in candash despite it showing on the center display.

This is because the onboard logic changed at some point in the last year:
Before: disabling AHB in the UI while on autopilot would allow manual HB control, even in AP.
Now: AHB cannot be disabled in the UI while on autopilot, only can be temporarily disabled using the stalk.

Now it is enough to just look at the HB-request signal, which simplifies the logic.