### PR TITLE
Hacky fix for TACC active icon on 2023.44.30

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
+++ b/android/app/src/main/java/app/candash/cluster/CANSignalHelper.kt
@@ -3,6 +3,7 @@ package app.candash.cluster
 import android.content.SharedPreferences
 import android.util.Log
 import java.lang.Float.max
+import kotlin.math.roundToInt
 
 class CANSignalHelper(val sharedPreferences: SharedPreferences) {
     private val TAG = CANSignalHelper::class.java.simpleName
@@ -279,7 +280,12 @@ class CANSignalHelper(val sharedPreferences: SharedPreferences) {
         }
         insertAugmentedCANSignal(SName.accActive, listOf(SName.accState, SName.accSpeedLimit)) {
             // accSpeedLimit is 204.6f (SNA) while TACC is active
-            if (it[SName.accState] == 4f && it[SName.accSpeedLimit] == 204.6f) {
+            // on 2023.44.30+, it's 102.2f while TACC is active
+            // TODO: once 44.30 dbc is available, look for a better signal, this is def wrong.
+
+            // round to tenths to fix floating point errors
+            val accSpeedLimit = if (it[SName.accSpeedLimit] != null) (it[SName.accSpeedLimit]!! * 10f).roundToInt() / 10f else null
+            if (it[SName.accState] == 4f && (accSpeedLimit == 204.6f || accSpeedLimit == 102.2f)) {
                 accActive = 1f
             }
             // accActive stays latched on until accState is cancelled


### PR DESCRIPTION
Tested via log replays of old (< 2023.44.30) and new (202344.30.2) firmware logs.

Something has changed about the signals, but until we get new DBCs, we don't know how to properly decode the signal yet.

However with the current decoding, it appears that while TACC is active, the value remains at 102.2 (with some FP rounding error)