### PR TITLE
Use static gradient for L1 BSW to match OEM

### DIFF
--- a/android/app/src/main/res/drawable/bsm_gradient.xml
+++ b/android/app/src/main/res/drawable/bsm_gradient.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:type="linear"
+        android:startColor="#FFFF0000"
+        android:endColor="#00FF0000"
+        android:angle="0"
+        />
+</shape>

--- a/android/app/src/main/res/layout/fragment_dash.xml
+++ b/android/app/src/main/res/layout/fragment_dash.xml
@@ -1580,6 +1580,27 @@
         tools:text="0 W" />
 
     <ImageView
+        android:id="@+id/blindSpotGradientLeft"
+        android:layout_width="100dp"
+        android:layout_height="match_parent"
+        android:src="@drawable/bsm_gradient"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"
+        />
+
+    <ImageView
+        android:id="@+id/blindSpotGradientRight"
+        android:layout_width="100dp"
+        android:layout_height="match_parent"
+        android:src="@drawable/bsm_gradient"
+        android:rotation="180"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"
+        />
+
+    <ImageView
         android:id="@+id/warning_gradient_overlay"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
Since level 1 BSW is now a little over-zealous, this PR makes level 1 a static (non-flashing) gradient when the turn signal is on, to match the OEM gradient in the camera view.

In my testing so far, level 1 always appears with a gradient in the camera, so by switching from the flash to static gradient, the BSW behavior should perfectly match that on the center display.

This change is separate from BSM arcs, if arcs are disabled, the gradient still shows when the turn signal is on. If arcs are enabled, you'll see see both the arcs and the gradient when the signal is on. The gradient never shows when the signal is off.