### PR TITLE
Fix battery and autopilot colors

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
+++ b/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
@@ -12,10 +12,10 @@ import androidx.core.content.ContextCompat
 class BatteryGauge @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : View(context, attrs, defStyleAttr) {
-    private var lightMode : Int = 0
+    private var lightMode : Int = 1
     private var isChargeMode : Boolean = false
     private var lineColor : ColorFilter = PorterDuffColorFilter(resources.getColor(R.color.dark_gray), PorterDuff.Mode.SRC_ATOP)
-    private var backgroundLineColor : ColorFilter = PorterDuffColorFilter(Color.parseColor("#FFAAAAAA"), PorterDuff.Mode.SRC_ATOP)
+    private var backgroundLineColor : ColorFilter = PorterDuffColorFilter(resources.getColor(R.color.battery_bg_day), PorterDuff.Mode.SRC_ATOP)
 
     private var powerPercent : Float = 50f
 
@@ -40,7 +40,7 @@ class BatteryGauge @JvmOverloads constructor(
 
     private fun drawClassic(canvas: Canvas) {
         // first insert @drawable/ic_deadbattery
-        val deadBattery = ContextCompat.getDrawable(context, R.drawable.ic_deadbattery)
+        val deadBattery = if (lightMode == 1) ContextCompat.getDrawable(context, R.drawable.ic_deadbattery) else ContextCompat.getDrawable(context, R.drawable.ic_deadbattery_night)
         deadBattery?.setBounds(0, 0, 50.px, 20.px)
         deadBattery?.draw(canvas)
 
@@ -119,9 +119,9 @@ class BatteryGauge @JvmOverloads constructor(
             }
         }
         backgroundLineColor = if (lightMode == 1){
-            PorterDuffColorFilter(Color.parseColor("#FFAAAAAA"), PorterDuff.Mode.SRC_ATOP)
+            PorterDuffColorFilter(resources.getColor(R.color.battery_bg_day), PorterDuff.Mode.SRC_ATOP)
         } else {
-            PorterDuffColorFilter(Color.DKGRAY, PorterDuff.Mode.SRC_ATOP)
+            PorterDuffColorFilter(resources.getColor(R.color.battery_bg_night), PorterDuff.Mode.SRC_ATOP)
         }
         this.invalidate()
     }

--- a/android/app/src/main/res/drawable/ic_autopilot.xml
+++ b/android/app/src/main/res/drawable/ic_autopilot.xml
@@ -13,7 +13,7 @@
           android:pathData="M2347,1173C2347,1379 2293,1582 2190,1760 2087,1939 1939,2087 1760,2190 1582,2293 1379,2347 1174,2347 968,2347 765,2293 587,2190 408,2087 260,1939 157,1760 54,1582 0,1379 0,1173 0,968 54,765 157,587 260,408 408,260 587,157 765,54 968,0 1174,0 1379,0 1582,54 1760,157 1939,260 2087,408 2190,587 2293,765 2347,968 2347,1173L2347,1173Z"
           android:strokeLineJoin="round"
           android:strokeWidth="28.222"
-          android:fillColor="#0048FF"
+          android:fillColor="@color/autopilot_blue"
           android:strokeColor="#00000000"
           android:fillType="evenOdd"/>
       <path

--- a/android/app/src/main/res/drawable/ic_deadbattery_night.xml
+++ b/android/app/src/main/res/drawable/ic_deadbattery_night.xml
@@ -6,11 +6,11 @@
   <path
       android:pathData="M47.193,4.5092L47.8606,4.5092A1.2685,0.9732 90,0 1,48.8338 5.7777L48.8338,13.3501A1.2685,0.9732 90,0 1,47.8606 14.6186L47.193,14.6186A1.2685,0.9732 90,0 1,46.2198 13.3501L46.2198,5.7777A1.2685,0.9732 90,0 1,47.193 4.5092z"
       android:strokeWidth="0"
-      android:fillColor="@color/battery_bg_day"
-      android:strokeColor="@color/battery_bg_day"/>
+      android:fillColor="@color/battery_bg_night"
+      android:strokeColor="@color/battery_bg_night"/>
   <path
       android:pathData="M3.3152,0L42.3882,0A4.0254,3.3152 90,0 1,45.7034 4.0254L45.7034,15.1023A4.0254,3.3152 90,0 1,42.3882 19.1278L3.3152,19.1278A4.0254,3.3152 90,0 1,0 15.1023L0,4.0254A4.0254,3.3152 90,0 1,3.3152 0z"
       android:strokeWidth="0"
-      android:fillColor="@color/battery_bg_day"
-      android:strokeColor="@color/battery_bg_day"/>
+      android:fillColor="@color/battery_bg_night"
+      android:strokeColor="@color/battery_bg_night"/>
 </vector>

--- a/android/app/src/main/res/drawable/ic_tacc.xml
+++ b/android/app/src/main/res/drawable/ic_tacc.xml
@@ -5,7 +5,7 @@
     android:viewportHeight="800">
   <path
       android:pathData="M400,400m-400,0a400,400 0,1 1,800 0a400,400 0,1 1,-800 0"
-      android:fillColor="#0048ff"/>
+      android:fillColor="@color/autopilot_blue"/>
   <path
       android:pathData="M399.87,399.96m-73.98,0a73.98,73.98 0,1 1,147.96 0a73.98,73.98 0,1 1,-147.96 0"
       android:strokeWidth="45"

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -19,13 +19,15 @@
     <color name="prnd_not_selected">#FFDDDDDD</color>
     <color name="day_background">#FFEEEEEE</color>
     <color name="night_background">#FF000000</color>
-    <color name="autopilot_blue">#FF0048FF</color>
+    <color name="autopilot_blue">#FF3E6BE2</color>
     <color name="autopilot_inactive">#FF808080</color>
     <color name="start_color">#4CAF50</color>
     <color name="stop_color">#F44336</color>
     <color name="light_gray">#EEEEEE</color>
     <color name="medium_gray">#CCCCCC</color>
     <color name="dark_gray">#444444</color>
+    <color name="battery_bg_night">#FF333333</color>
+    <color name="battery_bg_day">#FFA7A7A7</color>
     <color name="telltale_darkgreen">#00A933</color>
     <color name="telltale_green">#02e359</color>
     <color name="telltale_orange">#ffb641</color>


### PR DESCRIPTION
I'm not sure if because it changed recently, but I noticed the autopilot blue on the car is a lighter color (verified by peaking) than what we were using in candash.

Also, due to the cybermode pr, we lost the tinting of the battery background, causing it to be the wrong color.

This tweaks the autopilot blue, and adds the correct battery background colors (and new drawable so that tinting is not needed).