### PR TITLE
Fix autopilot blue

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -19,7 +19,7 @@
     <color name="prnd_not_selected">#FFDDDDDD</color>
     <color name="day_background">#FFEEEEEE</color>
     <color name="night_background">#FF000000</color>
-    <color name="autopilot_blue">#FF3E6BE2</color>
+    <color name="autopilot_blue">#FF0070FF</color>
     <color name="autopilot_inactive">#FF808080</color>
     <color name="start_color">#4CAF50</color>
     <color name="stop_color">#F44336</color>


### PR DESCRIPTION
A partial revert of the recent autopilot blue change which ended up being too dark compared to oem.

Turns out the blue used on the wheel icon is lighter than the blue used elsewhere, and I grabbed the wrong value.