### PR TITLE
Hide efficiency while charging

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -226,6 +226,7 @@ class DashFragment : Fragment() {
         setOf(
             binding.powerBar,
             binding.power,
+            binding.efficiency,
             binding.speed,
             binding.unit
         )


### PR DESCRIPTION
Since the efficiency text now shows at 0 speed, it needed to be added to the drivingViews so that it's hidden while charging, otherwise it interferes with the charging circle gauge.