### PR TITLE
Fix crash when dash fragment loads in splitscreen

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -320,11 +320,10 @@ class DashFragment : Fragment() {
 
         binding.blackout.visible = false
 
-        if (!isSplitScreen()) {
-            for (topUIView in topUIViews()) {
-                savedLayoutParams[topUIView] =
-                    ConstraintLayout.LayoutParams(topUIView.layoutParams as ConstraintLayout.LayoutParams)
-            }
+        // The initial layout params are saved onViewCreated, used later when switching between splitscreen modes
+        for (topUIView in topUIViews()) {
+            savedLayoutParams[topUIView] =
+                ConstraintLayout.LayoutParams(topUIView.layoutParams as ConstraintLayout.LayoutParams)
         }
 
         // This is executed now to kick-start some logic even before we get car state data


### PR DESCRIPTION
When loading dash fragment while already in splitscreen, the savedLayoutParams map was never populated, and thus when downstream logic attempted to use that map, it would crash.

There's no reason not to save the initial layout params even while in splitscreen, it only saves on initial view creation so it's guaranteed to be the original layout params for each view, before the splitscreen listener modifies them.

Tested by putting app in splitscreen, then going to info fragment and back to dash fragment (recreated crash before this change, no crash after this change, view margins are still correctly modified)