### PR TITLE
Actually hide efficiency when charging

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -752,7 +752,7 @@ class DashFragment : Fragment() {
         // Power is always changing, it's enough to only observe this for rapid updates to the efficiency view
         viewModel.onSignal(viewLifecycleOwner, SName.power) {
             val efficiencyText = efficiencyCalculator.getEfficiencyText()
-            if (efficiencyText == null || prefs.getBooleanPref(Constants.hideEfficiency) || isSplitScreen()) {
+            if (efficiencyText == null || prefs.getBooleanPref(Constants.hideEfficiency) || isSplitScreen() || carIsCharging()) {
                 binding.efficiency.visible = false
             } else {
                 binding.efficiency.text = efficiencyText


### PR DESCRIPTION
Follow-on from #87: drivingViews and the power signal listener were competing with each other to show/hide the efficiency binding.

This fixes it to ensure it isn't set visible again after it's hidden.