### PR TITLE
Fix minpower from DCFC edge case

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -547,8 +547,8 @@ class DashFragment : Fragment() {
         viewModel.onSignal(viewLifecycleOwner, SName.power) {
             if (it != null) {
                 if (it > prefs.getPref("maxPower")) prefs.setPref("maxPower", it)
-                if (!carIsCharging()) {
-                    // do not store min power if car is charging
+                if (gearState() in setOf(SVal.gearDrive, SVal.gearReverse)) {
+                    // Only store min power when car is driving
                     if (it < prefs.getPref("minPower")) prefs.setPref("minPower", it)
                 }
                 binding.minpower.text = formatPower(prefs.getPref("minPower"))


### PR DESCRIPTION
An edge case can occur when candash (re)starts while charging, if it receives the power signal before the charge status signal, it can momentarily update minpower with the value caused by charging.

This fixes it by only saving minpower while gearstate is in drive or reverse...this means that even if we're missing the gear signal, it won't save (failsafe, as not updating minpower when unsure is better).