### PR TITLE
Fix battery margins to better match the original battery icon

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
+++ b/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
@@ -54,7 +54,7 @@ class BatteryGauge @JvmOverloads constructor(
     private fun lineColor(): ColorFilter {
         return if (isChargeMode) {
             chargeColor
-        } else if (powerPercent <= 10) {
+        } else if (powerPercent <= 5) {
             veryLowColor
         } else if (powerPercent <= 20) {
             lowColor
@@ -69,12 +69,16 @@ class BatteryGauge @JvmOverloads constructor(
         val battHeight = 20f.px
         val capWidth = 4f.px
         val margin = 1.75f.px
+        val minBattThickness = 4f.px
         val deadBattery = ContextCompat.getDrawable(context, R.drawable.ic_deadbattery)
         deadBattery?.setBounds(0, 0, battWidth.toInt(), battHeight.toInt())
         deadBattery?.draw(canvas)
 
         // then draw mask with rounded corners, filled by powerWidth
-        val powerWidth = powerPercent / 100 * (battWidth - capWidth - margin * 2)
+        var powerWidth = powerPercent / 100 * (battWidth - capWidth - margin * 2)
+        if (powerPercent > 0 && powerWidth < minBattThickness) {
+            powerWidth = minBattThickness
+        }
         val paint = Paint()
         paint.setColorFilter(lineColor())
         val path = Path()

--- a/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
+++ b/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
@@ -36,8 +36,8 @@ class BatteryGauge @JvmOverloads constructor(
         backgroundColor = PorterDuffColorFilter(typedValue.data, PorterDuff.Mode.SRC_ATOP)
 
         chargeColor = PorterDuffColorFilter(resources.getColor(R.color.telltale_green), PorterDuff.Mode.SRC_ATOP)
-        lowColor = PorterDuffColorFilter(resources.getColor(R.color.telltale_orange), PorterDuff.Mode.SRC_ATOP)
-        veryLowColor = PorterDuffColorFilter(resources.getColor(R.color.telltale_red), PorterDuff.Mode.SRC_ATOP)
+        lowColor = PorterDuffColorFilter(resources.getColor(R.color.battery_orange), PorterDuff.Mode.SRC_ATOP)
+        veryLowColor = PorterDuffColorFilter(resources.getColor(R.color.battery_red), PorterDuff.Mode.SRC_ATOP)
     }
 
     override fun onDraw(canvas: Canvas?) {
@@ -54,7 +54,7 @@ class BatteryGauge @JvmOverloads constructor(
     private fun lineColor(): ColorFilter {
         return if (isChargeMode) {
             chargeColor
-        } else if (powerPercent <= 5) {
+        } else if (powerPercent <= 7) {
             veryLowColor
         } else if (powerPercent <= 20) {
             lowColor
@@ -69,7 +69,7 @@ class BatteryGauge @JvmOverloads constructor(
         val battHeight = 20f.px
         val capWidth = 4f.px
         val margin = 1.75f.px
-        val minBattThickness = 4f.px
+        val minBattThickness = 3f.px
         val deadBattery = ContextCompat.getDrawable(context, R.drawable.ic_deadbattery)
         deadBattery?.setBounds(0, 0, battWidth.toInt(), battHeight.toInt())
         deadBattery?.draw(canvas)

--- a/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
+++ b/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
@@ -49,15 +49,30 @@ class BatteryGauge @JvmOverloads constructor(
 
     private fun drawClassic(canvas: Canvas) {
         // first insert @drawable/ic_deadbattery
+        val battWidth = 50f.px
+        val battHeight = 20f.px
+        val capWidth = 4f.px
+        val margin = 1.75f.px
         val deadBattery = ContextCompat.getDrawable(context, R.drawable.ic_deadbattery)
-        deadBattery?.setBounds(0, 0, 50.px, 20.px)
+        deadBattery?.setBounds(0, 0, battWidth.toInt(), battHeight.toInt())
         deadBattery?.draw(canvas)
 
-        val powerWidth = powerPercent / 100 * 41f
+        // then draw mask with rounded corners, filled by powerWidth
+        val powerWidth = powerPercent / 100 * (battWidth - capWidth - margin * 2)
         val paint = Paint()
-        paint.strokeWidth = 15f.px
         paint.setColorFilter(if (isChargeMode) chargeColor else lineColor)
-        canvas.drawLine(3f.px, 10f.px, (3f+powerWidth).px, 10f.px, paint)
+        val path = Path()
+        path.addRoundRect(
+            margin,
+            margin,
+            battWidth - capWidth - margin,
+            battHeight - margin,
+            2.5f.px,
+            2.5f.px,
+            Path.Direction.CW
+        )
+        canvas.clipPath(path)
+        canvas.drawRect(margin, margin, margin + powerWidth, battHeight - margin, paint)
     }
 
     private fun drawCyber(canvas: Canvas) {

--- a/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
+++ b/android/app/src/main/java/app/candash/cluster/BatteryGauge.kt
@@ -16,7 +16,9 @@ class BatteryGauge @JvmOverloads constructor(
     private var isChargeMode : Boolean = false
     private var lineColor : ColorFilter
     private var backgroundColor : ColorFilter
-    private var chargeColor : ColorFilter
+    private val chargeColor : ColorFilter
+    private val lowColor : ColorFilter
+    private val veryLowColor : ColorFilter
     private var cyber : Boolean = false
 
     private var powerPercent : Float = 50f
@@ -34,6 +36,8 @@ class BatteryGauge @JvmOverloads constructor(
         backgroundColor = PorterDuffColorFilter(typedValue.data, PorterDuff.Mode.SRC_ATOP)
 
         chargeColor = PorterDuffColorFilter(resources.getColor(R.color.telltale_green), PorterDuff.Mode.SRC_ATOP)
+        lowColor = PorterDuffColorFilter(resources.getColor(R.color.telltale_orange), PorterDuff.Mode.SRC_ATOP)
+        veryLowColor = PorterDuffColorFilter(resources.getColor(R.color.telltale_red), PorterDuff.Mode.SRC_ATOP)
     }
 
     override fun onDraw(canvas: Canvas?) {
@@ -44,6 +48,18 @@ class BatteryGauge @JvmOverloads constructor(
             drawCyber(canvas)
         } else {
             drawClassic(canvas)
+        }
+    }
+
+    private fun lineColor(): ColorFilter {
+        return if (isChargeMode) {
+            chargeColor
+        } else if (powerPercent <= 10) {
+            veryLowColor
+        } else if (powerPercent <= 20) {
+            lowColor
+        } else {
+            lineColor
         }
     }
 
@@ -60,7 +76,7 @@ class BatteryGauge @JvmOverloads constructor(
         // then draw mask with rounded corners, filled by powerWidth
         val powerWidth = powerPercent / 100 * (battWidth - capWidth - margin * 2)
         val paint = Paint()
-        paint.setColorFilter(if (isChargeMode) chargeColor else lineColor)
+        paint.setColorFilter(lineColor())
         val path = Path()
         path.addRoundRect(
             margin,
@@ -104,7 +120,7 @@ class BatteryGauge @JvmOverloads constructor(
             canvas.drawPath(path, paint)
         }
         // draw full lines, same as above, but only up to powerPercent
-        paint.setColorFilter(if (isChargeMode) chargeColor else lineColor)
+        paint.setColorFilter(lineColor())
         for (i in 0 until fullLineCount) {
             path.reset()
             path.moveTo(i * step, bottom) // bottom left

--- a/android/app/src/main/res/drawable/ic_deadbattery.xml
+++ b/android/app/src/main/res/drawable/ic_deadbattery.xml
@@ -1,7 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="48.83384dp"
     android:height="19.127771dp"
-    android:viewportWidth="48.83384"
+    android:viewportWidth="49.83384"
     android:viewportHeight="19.127771">
   <path
       android:pathData="M47.193,4.5092L47.8606,4.5092A1.2685,0.9732 90,0 1,48.8338 5.7777L48.8338,13.3501A1.2685,0.9732 90,0 1,47.8606 14.6186L47.193,14.6186A1.2685,0.9732 90,0 1,46.2198 13.3501L46.2198,5.7777A1.2685,0.9732 90,0 1,47.193 4.5092z"

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -21,6 +21,8 @@
     <color name="telltale_red">#ff3a3a</color>
     <color name="telltale_blue">#006cff</color>
     <color name="telltale_inactive">#909090</color>
+    <color name="battery_orange">#ffffa555</color>
+    <color name="battery_red">#ffff4444</color>
     <color name="very_red">#ff0000</color>
     <color name="transparent_blank">#00000000</color>
 


### PR DESCRIPTION
A small visual tweak to fix the margins between the battery background and fill, and to add rounded corners to the fill. It also fixes the edge of the cap being clipped.

![image](https://github.com/nmullaney/candash/assets/54586926/34932b1e-5a19-4a2b-8e44-048c66d46ed9)

This now matches the oem icon much more closely.