### PR TITLE
Efficiency graph updates

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -424,10 +424,10 @@ class DashFragment : Fragment() {
         binding.efficiency.setOnLongClickListener {
             if (prefs.getBooleanPref(Constants.hideEfficiencyChart)) {
                 prefs.setBooleanPref(Constants.hideEfficiencyChart, false)
-                binding.infoToast.text = "Showing efficiency chart"
+                binding.infoToast.text = "Efficiency chart enabled"
             } else {
                 prefs.setBooleanPref(Constants.hideEfficiencyChart, true)
-                binding.infoToast.text = "Hiding efficiency chart"
+                binding.infoToast.text = "Efficiency chart disabled"
             }
             binding.infoToast.visible = true
             binding.infoToast.startAnimation(fadeOut(5000))

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -422,8 +422,13 @@ class DashFragment : Fragment() {
         }
 
         binding.efficiency.setOnLongClickListener {
-            efficiencyCalculator.clearHistory()
-            binding.infoToast.text = "Cleared efficiency history"
+            if (prefs.getBooleanPref(Constants.hideEfficiencyChart)) {
+                prefs.setBooleanPref(Constants.hideEfficiencyChart, false)
+                binding.infoToast.text = "Showing efficiency chart"
+            } else {
+                prefs.setBooleanPref(Constants.hideEfficiencyChart, true)
+                binding.infoToast.text = "Hiding efficiency chart"
+            }
             binding.infoToast.visible = true
             binding.infoToast.startAnimation(fadeOut(5000))
             updateEfficiencyChart(efficiencyCalculator)

--- a/android/app/src/main/java/app/candash/cluster/EfficiencyCalculator.kt
+++ b/android/app/src/main/java/app/candash/cluster/EfficiencyCalculator.kt
@@ -35,24 +35,10 @@ class EfficiencyCalculator(
         val index = (options.indexOf(old) + 1) % options.size
         prefs.setPref(Constants.efficiencyLookBack, options[index])
 
-        // When it cycles back to 0, toggle the efficiency chart
-        var chartString = ""
-        if (options[index] == 0f) {
-            prefs.setBooleanPref(
-                Constants.hideEfficiencyChart,
-                !prefs.getBooleanPref(Constants.hideEfficiencyChart)
-            )
-            chartString = if (prefs.getBooleanPref(Constants.hideEfficiencyChart)) {
-                " (chart off)"
-            } else {
-                " (chart on)"
-            }
-        }
-
         return if (inMiles) {
-            "Last %.0f miles%s".format(options[index].kmToMi, chartString)
+            "Last %.0f miles".format(options[index].kmToMi)
         } else {
-            "Last %.0f km%s".format(options[index], chartString)
+            "Last %.0f km".format(options[index])
         }
     }
 

--- a/android/app/src/main/java/app/candash/cluster/EfficiencyChart.kt
+++ b/android/app/src/main/java/app/candash/cluster/EfficiencyChart.kt
@@ -45,7 +45,7 @@ class EfficiencyChart @JvmOverloads constructor(
         super.onDraw(canvas)
         if (canvas == null) return
 
-        this.alpha = 0.5f
+        this.alpha = 0.3f
         drawLineChart(canvas, odoEfficiencyToPointF(odoEfficiencyPairs))
     }
 
@@ -67,7 +67,7 @@ class EfficiencyChart @JvmOverloads constructor(
 
         val zeroY = efficiencyToY(0f)
         val firstX = points[0].x
-        val fullPositiveColor = efficiencyToY(400f)
+        val fullPositiveColor = efficiencyToY(200f)
 
         val negativeShader =
             LinearGradient(

--- a/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
@@ -57,6 +57,15 @@ class SettingsFragment() : Fragment() {
         binding.displaySync.isChecked = !prefs.getBooleanPref(Constants.disableDisplaySync)
         binding.autoBrightness.isChecked = !prefs.getBooleanPref(Constants.disableAutoBrightness)
         binding.showEfficiency.isChecked = !prefs.getBooleanPref(Constants.hideEfficiency)
+        // Uncheck and disable efficiency chart if efficiency is hidden
+        if (!binding.showEfficiency.isChecked) {
+            binding.showEfficiencyChart.isChecked = false
+            binding.showEfficiencyChart.isEnabled = false
+            binding.showEfficiencyChart.alpha = 0.3f
+        } else {
+            binding.showEfficiencyChart.isChecked = !prefs.getBooleanPref(Constants.hideEfficiencyChart)
+            binding.showEfficiencyChart.alpha = 1f
+        }
         if (prefs.getBooleanPref(Constants.tempInF)) {
             binding.tempUnitF.isChecked = true
         } else {
@@ -73,6 +82,14 @@ class SettingsFragment() : Fragment() {
             binding.torqueUnitNm.isChecked = true
         }
 
+        // Update efficiency chart checkbox on efficiency checkbox change
+        binding.showEfficiency.setOnCheckedChangeListener { _, isChecked ->
+            binding.showEfficiencyChart.isEnabled = isChecked
+            binding.showEfficiencyChart.alpha = if (isChecked) 1f else 0.3f
+            if (!isChecked) {
+                binding.showEfficiencyChart.isChecked = false
+            }
+        }
     }
 
 
@@ -122,6 +139,11 @@ class SettingsFragment() : Fragment() {
             prefs.setBooleanPref(Constants.hideEfficiency, false)
         } else {
             prefs.setBooleanPref(Constants.hideEfficiency, true)
+        }
+        if (binding.showEfficiencyChart.isChecked) {
+            prefs.setBooleanPref(Constants.hideEfficiencyChart, false)
+        } else {
+            prefs.setBooleanPref(Constants.hideEfficiencyChart, true)
         }
         when (binding.tempUnits.checkedRadioButtonId) {
             R.id.tempUnitC -> prefs.setBooleanPref(Constants.tempInF, false)

--- a/android/app/src/main/res/layout/fragment_settings.xml
+++ b/android/app/src/main/res/layout/fragment_settings.xml
@@ -91,7 +91,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
 
-        app:layout_constraintGuide_percent=".333" />
+        app:layout_constraintGuide_percent=".3" />
 
     <TextView
         android:id="@+id/displayOptionsLabel"
@@ -141,13 +141,22 @@
         app:layout_constraintTop_toBottomOf="@id/showSpeedLimit" />
 
     <CheckBox
+        android:id="@+id/showEfficiencyChart"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="44dp"
+        android:text="Show Efficiency Chart"
+        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
+        app:layout_constraintTop_toBottomOf="@id/showEfficiency" />
+
+    <CheckBox
         android:id="@+id/autoBrightness"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
         android:text="Automatically Adjust Brightness"
         app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
-        app:layout_constraintTop_toBottomOf="@id/showEfficiency" />
+        app:layout_constraintTop_toBottomOf="@id/showEfficiencyChart" />
 
     <CheckBox
         android:id="@+id/displaySync"
@@ -162,8 +171,8 @@
         android:id="@+id/blankDisplayHint"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingLeft="20dp"
-        android:text="Long-press left side of screen to return\nto settings while display is off.\nRecommended only with OLED screens."
+        android:paddingLeft="52dp"
+        android:text="Recommended only with OLED screens."
         android:textSize="12dp"
         app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
         app:layout_constraintTop_toBottomOf="@id/displaySync" />
@@ -175,7 +184,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
 
-        app:layout_constraintGuide_percent=".667" />
+        app:layout_constraintGuide_percent=".7" />
 
     <TextView
         android:id="@+id/unitsLabel"
@@ -272,7 +281,7 @@
         android:gravity="center"
         android:text="Save"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toLeftOf="@id/guidelinevright"
+        app:layout_constraintRight_toLeftOf="@id/guidelinevleft"
 
         />
 
@@ -286,8 +295,7 @@
         android:gravity="center"
         android:text="Cancel"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toRightOf="@id/guidelinevleft"
-
+        app:layout_constraintLeft_toLeftOf="parent"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
A few minor tweaks based on user feedback:

- Adjust gradient opacity to make the zero line less distracting
  - Also move the gradient position closer to the line, now the gradient is equal on both pos and neg sides of the line
- Fix a bug causing the pos and neg lines to overlap slightly when crossing the zero line
  - Mostly noticeable in the fragment preview, but visible IRL when looking closely.
- Move chart toggle to settings fragment, and change efficiency long-press to toggle chart instead of reset efficiency
  - Chart visibility depends on efficiency visibility, so the settings checkbox behavior reflects that dependency.
  - The settings fragment layout was adjusted slightly to accommodate the extra checkbox, as the middle column was crowded
    - Removed "Long-press screen when display off" text because it's no longer relevant and incorrect (now it's just tap to wake)