### PR TITLE
Remove unnecessary permission prompt for party alarm

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/MockCANService.kt
+++ b/android/app/src/main/java/app/candash/cluster/MockCANService.kt
@@ -19,7 +19,9 @@ class MockCANService : CANService {
         withContext(pandaContext) {
             shutdown = false
             while (!shutdown) {
-                val newState = mockCarStates()[count.getAndAdd(1) % mockCarStates().size]
+                val mockStates = mockCarStates()
+                // val mockStates = mockPartyStates()
+                val newState = mockStates[count.getAndAdd(1) % mockStates.size]
                 carState.clear()
                 liveCarState.clear()
                 for (state in newState) {
@@ -161,110 +163,33 @@ class MockCANService : CANService {
             ))
         )
 
-
-}
-/*
-    private fun mockCarStates() : List<CarState> =
+    private fun mockPartyStates(): List<CarState> =
         listOf(
             createCarState(mutableMapOf(
-                SName.battVolts to 390.1f,
-                SName.frontLeftDoorState to 1.0f,
-                SName.displayBrightnessLev to 11.5f,
-                SName.stateOfCharge to 1.0f,
-                SName.uiRange to 273.0f,
-                SName.uiSpeed to 0.0f,
-                //SName.blindSpotLeft to 3.0f,
-                SName.blindSpotRight to 0.0f,
-                SName.turnSignalLeft to 1.0f,
-                SName.isDarkMode to 0.0f,
-                SName.autopilotState to 2f,
-                SName.autopilotHands to 1f,
-                SName.uiSpeedUnits to 0f,
-                SName.gearSelected to SVal.gearPark,
-                SName.battAmps to 20.0f,
-                SName.displayOn to 1f
-
+                SName.keepClimateReq to SVal.keepClimateParty,
+                SName.stateOfCharge to 69f,
+                SName.outsideTemp to 24f,
+                SName.insideTemp to 20f,
+                SName.insideTempReq to 20f,
+                SName.battBrickMin to 35f,
+                SName.dc12vPower to 200f,
+                SName.power to 400f,
+                SName.slowPower to 400f,
+                SName.partyHoursLeft to 2f,
+                SName.frontOccupancy to 2f,
             )),
             createCarState(mutableMapOf(
-                SName.battVolts to 390.0f,
-                SName.frontLeftDoorState to 1.0f,
-
-                SName.displayBrightnessLev to 10.5f,
-                SName.stateOfCharge to 79.0f,
-                SName.uiRange to 270.0f,
-                SName.uiSpeed to 20.0f,
-                //SName.blindSpotLeft to 3.0f,
-                SName.blindSpotRight to 0.0f,
-                SName.turnSignalLeft to 2.0f,
-                SName.turnSignalRight to 1.0f,
-                SName.isDarkMode to 0.0f,
-                SName.autopilotState to 1f,
-                SName.autopilotHands to 3f,
-                SName.cruiseControlSpeed to 45.0f,
-                SName.uiSpeedUnits to 0f,
-                SName.gearSelected to SVal.gearPark,
-                SName.battAmps to 140.0f,
-                SName.displayOn to 1f
+                SName.keepClimateReq to SVal.keepClimateParty,
+                SName.stateOfCharge to 60f,
+                SName.outsideTemp to 24f,
+                SName.insideTemp to 20f,
+                SName.insideTempReq to 20f,
+                SName.battBrickMin to 35f,
+                SName.dc12vPower to 200f,
+                SName.power to 400f,
+                SName.slowPower to 400f,
+                SName.partyHoursLeft to 2f,
+                SName.frontOccupancy to 2f,
             )),
-            createCarState(mutableMapOf(
-                SName.battVolts to 389.9f,
-                //SName.blindSpotLeft to 1.0f,
-                //SName.blindSpotRight to 1.0f,
-                SName.displayBrightnessLev to 9.5f,
-                SName.stateOfCharge to 50.0f,
-                SName.uiRange to 268.0f,
-                SName.uiSpeed to 21.0f,
-                SName.blindSpotLeft to 0.0f,
-                //SName.blindSpotRight to 2.0f,
-                SName.turnSignalLeft to 1.0f,
-                SName.turnSignalRight to 1.0f,
-                SName.isDarkMode to 0.0f,
-                SName.autopilotState to 3f,
-                SName.autopilotHands to 3f,
-                SName.maxSpeedAP to 45.0f,
-                SName.cruiseControlSpeed to 45.0f,
-                SName.uiSpeedUnits to 0f,
-                SName.gearSelected to SVal.gearDrive,
-                SName.battAmps to 3.0f,
-                SName.displayOn to 1f
-            )),
-            createCarState(mutableMapOf(
-                SName.battVolts to 389.8f,
-                SName.displayBrightnessLev to 8.5f,
-                SName.stateOfCharge to 25.0f,
-                SName.uiRange to 265.0f,
-                SName.uiSpeed to 25.0f,
-
-                SName.turnSignalLeft to 0.0f,
-                SName.turnSignalRight to 1.0f,
-                SName.isDarkMode to 0.0f,
-                SName.autopilotState to 3f,
-                SName.autopilotHands to 3f,
-                SName.maxSpeedAP to 45.0f,
-                SName.uiSpeedUnits to 0f,
-                SName.cruiseControlSpeed to 45.0f,
-                SName.battAmps to 750.0f,
-                SName.displayOn to 1f
-            )),
-            createCarState(mutableMapOf(
-                SName.battVolts to 389.7f,
-
-                SName.displayBrightnessLev to 7.5f,
-                SName.stateOfCharge to 76.0f,
-                SName.uiRange to 264.0f,
-                SName.uiSpeed to 29.0f,
-
-                SName.turnSignalLeft to 0.0f,
-                SName.turnSignalRight to 1.0f,
-                SName.isDarkMode to 1.0f,
-                SName.autopilotState to 3f,
-                SName.autopilotHands to 1f,
-                SName.uiSpeedUnits to 0f,
-                SName.maxSpeedAP to 25.0f,
-                SName.cruiseControlSpeed to 23.0f,
-                SName.battAmps to -200.0f,
-                SName.displayOn to 1f
-            )))
+        )
 }
-
- */

--- a/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
@@ -1,19 +1,14 @@
 package app.candash.cluster
 
-import android.Manifest
 import android.content.Context
 import android.content.SharedPreferences
-import android.content.pm.PackageManager
-import android.graphics.Color
 import android.media.AudioAttributes
 import android.media.Ringtone
 import android.media.RingtoneManager
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import androidx.fragment.app.Fragment
@@ -119,16 +114,6 @@ class PartyFragment : Fragment() {
         alarmPlayer.stop()
     }
 
-    private fun isUriAccessible(uri: Uri): Boolean {
-        return try {
-            val inputStream = context?.contentResolver?.openInputStream(uri)
-            inputStream?.close()
-            true
-        } catch (e: Exception) {
-            false
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 
         prefs = requireContext().getSharedPreferences("dash", Context.MODE_PRIVATE)
@@ -136,42 +121,6 @@ class PartyFragment : Fragment() {
 
         // Use default alarm tone
         val alert = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
-        // This could be a file in external storage, so we need to ask for permission
-        // Check if alert uri is accessible, or if we need to ask for permission
-        if (!isUriAccessible(alert)) {
-            // Check if we have permission to read external storage
-            if (context?.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-                // Permission is not granted, request it
-                binding.infoToast.text = "Permission needed to read storage for SOC alarm tone, tap to allow"
-                binding.infoToast.visible = true
-                view.postDelayed({
-                    try {
-                        if (binding.infoToast.visible) {
-                            binding.infoToast.startAnimation(fadeOut(2000))
-                        }
-                    }
-                    catch (e: Exception) {
-                        return@postDelayed
-                    }
-
-                }, 8000)
-                view.postDelayed({
-                    try {
-                        binding.infoToast.setOnClickListener(null)
-                    }
-                    catch (e: Exception) {
-                        return@postDelayed
-                    }
-                }, 10000)
-                binding.infoToast.setOnClickListener {
-                    binding.infoToast.visible = false
-                    activity?.requestPermissions(
-                        arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE),
-                        101
-                    )
-                }
-            }
-        }
         alarmPlayer = RingtoneManager.getRingtone(this.context, alert)
         alarmPlayer.audioAttributes = AudioAttributes.Builder()
             .setUsage(AudioAttributes.USAGE_ALARM)
@@ -217,7 +166,9 @@ class PartyFragment : Fragment() {
 
         binding.partyTime.setOnClickListener {
             val newTarget = prefs.getPref(Constants.partyTimeTarget) + 5f
-            if (newTarget > 90f || alarmPlayer.isPlaying) {
+            if (newTarget > 90f || newTarget >= (viewModel.carState[SName.stateOfCharge]
+                    ?: 90f)
+            ) {
                 prefs.setPref(Constants.partyTimeTarget, 20f)
             } else {
                 prefs.setPref(Constants.partyTimeTarget, newTarget)
@@ -421,14 +372,12 @@ class PartyFragment : Fragment() {
         ) {
             if (!alarmPlayer.isPlaying) {
                 alarmPlayer.play()
-                updatePartyTime()
-                updateBlackout()
             }
         } else if (alarmPlayer.isPlaying) {
             alarmPlayer.stop()
-            updatePartyTime()
-            updateBlackout()
         }
+        updatePartyTime()
+        updateBlackout()
     }
 
     private fun processBattery() {

--- a/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
@@ -372,12 +372,14 @@ class PartyFragment : Fragment() {
         ) {
             if (!alarmPlayer.isPlaying) {
                 alarmPlayer.play()
+                updatePartyTime()
+                updateBlackout()
             }
         } else if (alarmPlayer.isPlaying) {
             alarmPlayer.stop()
+            updatePartyTime()
+            updateBlackout()
         }
-        updatePartyTime()
-        updateBlackout()
     }
 
     private fun processBattery() {


### PR DESCRIPTION
In digging into a seemingly buggy permissions prompt (it seemed that some api levels didn't require permission, or even would crash when attempting to request permission) I was unable to reproduce the need to request permission on any api level for the alarm to work.

This removes the entire permission request flow, adds a party option to the mock server to make it easier to test party mode, and a couple of other minor improvements in the party alarm update logic.