### PR TITLE
Move brightness and theme listener ownership to fragments

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -492,6 +492,37 @@ class DashFragment : Fragment() {
          * Remember that it will only run when the value of the signal(s) change
          */
 
+        viewModel.onSomeSignals(
+            viewLifecycleOwner, listOf(
+                SName.displayBrightnessLev,
+                SName.solarBrightnessFactor
+            )
+        ) {
+            val solarBrightnessFactor = it[SName.solarBrightnessFactor]
+            if (solarBrightnessFactor != null) {
+                prefs.setPref(Constants.lastSolarBrightnessFactor, solarBrightnessFactor)
+            }
+            viewModel.updateBrightness()
+        }
+
+        viewModel.onSignal(viewLifecycleOwner, SName.isDarkMode) {
+            if (it != null) {
+                if (it != prefs.getPref(Constants.lastDarkMode)) {
+                    prefs.setPref(Constants.lastDarkMode, it)
+                    viewModel.updateTheme()
+                }
+            }
+        }
+
+        viewModel.onSignal(viewLifecycleOwner, SName.isSunUp) {
+            if (it != null) {
+                if (it != prefs.getPref(Constants.lastSunUp)) {
+                    prefs.setPref(Constants.lastSunUp, it)
+                    viewModel.updateTheme()
+                }
+            }
+        }
+
         viewModel.onSignal(viewLifecycleOwner, SName.keepClimateReq) {
             if (it == SVal.keepClimateParty) {
                 viewModel.switchToPartyFragment()

--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -492,36 +492,8 @@ class DashFragment : Fragment() {
          * Remember that it will only run when the value of the signal(s) change
          */
 
-        viewModel.onSomeSignals(
-            viewLifecycleOwner, listOf(
-                SName.displayBrightnessLev,
-                SName.solarBrightnessFactor
-            )
-        ) {
-            val solarBrightnessFactor = it[SName.solarBrightnessFactor]
-            if (solarBrightnessFactor != null) {
-                prefs.setPref(Constants.lastSolarBrightnessFactor, solarBrightnessFactor)
-            }
-            viewModel.updateBrightness()
-        }
-
-        viewModel.onSignal(viewLifecycleOwner, SName.isDarkMode) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastDarkMode)) {
-                    prefs.setPref(Constants.lastDarkMode, it)
-                    viewModel.updateTheme()
-                }
-            }
-        }
-
-        viewModel.onSignal(viewLifecycleOwner, SName.isSunUp) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastSunUp)) {
-                    prefs.setPref(Constants.lastSunUp, it)
-                    viewModel.updateTheme()
-                }
-            }
-        }
+        viewModel.startThemeListener(viewLifecycleOwner)
+        viewModel.startBrightnessListener(viewLifecycleOwner)
 
         viewModel.onSignal(viewLifecycleOwner, SName.keepClimateReq) {
             if (it == SVal.keepClimateParty) {

--- a/android/app/src/main/java/app/candash/cluster/DashViewModel.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashViewModel.kt
@@ -27,6 +27,8 @@ class DashViewModel @Inject constructor(private val dashRepository: DashReposito
     private val _zeroConfIpAddress = MutableLiveData("0.0.0.0")
     private val _themeUpdate = MutableLiveData<Boolean>()
     val themeUpdate: LiveData<Boolean> = _themeUpdate
+    private val _brightnessUpdate = MutableLiveData<Boolean>()
+    val brightnessUpdate: LiveData<Boolean> = _brightnessUpdate
     val zeroConfIpAddress : LiveData<String>
         get() = _zeroConfIpAddress
     private var discoveryListener : NsdManager.DiscoveryListener? = null
@@ -34,6 +36,10 @@ class DashViewModel @Inject constructor(private val dashRepository: DashReposito
 
     fun updateTheme() {
         _themeUpdate.value = true
+    }
+
+    fun updateBrightness() {
+        _brightnessUpdate.value = true
     }
 
     fun getCurrentCANServiceIndex() : Int {

--- a/android/app/src/main/java/app/candash/cluster/DashViewModel.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashViewModel.kt
@@ -237,6 +237,41 @@ class DashViewModel @Inject constructor(private val dashRepository: DashReposito
     private fun createDiscoveryListener() : NsdManager.DiscoveryListener =
         NsdDiscoveryListener(nsdManager, _zeroConfIpAddress)
 
+
+    fun startThemeListener(owner: LifecycleOwner) {
+        this.onSignal(owner, SName.isDarkMode) {
+            if (it != null) {
+                if (it != sharedPreferences.getPref(Constants.lastDarkMode)) {
+                    sharedPreferences.setPref(Constants.lastDarkMode, it)
+                    this.updateTheme()
+                }
+            }
+        }
+
+        this.onSignal(owner, SName.isSunUp) {
+            if (it != null) {
+                if (it != sharedPreferences.getPref(Constants.lastSunUp)) {
+                    sharedPreferences.setPref(Constants.lastSunUp, it)
+                    this.updateTheme()
+                }
+            }
+        }
+    }
+
+    fun startBrightnessListener(owner: LifecycleOwner) {
+        this.onSomeSignals(
+            owner, listOf(
+                SName.displayBrightnessLev,
+                SName.solarBrightnessFactor
+            )
+        ) {
+            val solarBrightnessFactor = it[SName.solarBrightnessFactor]
+            if (solarBrightnessFactor != null) {
+                sharedPreferences.setPref(Constants.lastSolarBrightnessFactor, solarBrightnessFactor)
+            }
+            this.updateBrightness()
+        }
+    }
 }
 
 class NsdDiscoveryListener(

--- a/android/app/src/main/java/app/candash/cluster/FullscreenActivity.kt
+++ b/android/app/src/main/java/app/candash/cluster/FullscreenActivity.kt
@@ -132,39 +132,13 @@ class FullscreenActivity : AppCompatActivity() {
             switchToFragment(it)
         }
 
-        // Listen for carstate theme changes
-        viewModel.onSignal(this, SName.isDarkMode) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastDarkMode)) {
-                    prefs.setPref(Constants.lastDarkMode, it)
-                    applyThemeAndReload(getDashTheme())
-                }
-            }
-        }
-        viewModel.onSignal(this, SName.isSunUp) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastSunUp)) {
-                    prefs.setPref(Constants.lastSunUp, it)
-                    applyThemeAndReload(getDashTheme())
-                }
-            }
-        }
-        viewModel.onSignal(this, SName.solarBrightnessFactor) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastSolarBrightnessFactor)) {
-                    prefs.setPref(Constants.lastSolarBrightnessFactor, it)
-                }
-                setBrightness()
-            }
-        }
-
-        // Listen for manual theme changes
+        // Listen for theme changes
         viewModel.themeUpdate.observe(this) {
             applyThemeAndReload(getDashTheme())
         }
 
-        // Listen for display brightness changes
-        viewModel.onSignal(this, SName.displayBrightnessLev) {
+        // Listen for brightness changes
+        viewModel.brightnessUpdate.observe(this) {
             setBrightness()
         }
     }

--- a/android/app/src/main/java/app/candash/cluster/InfoFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/InfoFragment.kt
@@ -1,9 +1,7 @@
 package app.candash.cluster
 
 import android.content.ClipData
-import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.text.SpannableStringBuilder
@@ -27,7 +25,6 @@ class InfoFragment : Fragment() {
     private val TAG = InfoFragment::class.java.simpleName
     private lateinit var binding: FragmentInfoBinding
     private lateinit var viewModel: DashViewModel
-    private lateinit var prefs: SharedPreferences
 
     private val infoTextViews = mutableListOf<View>()
     private var zoomSignal: String? = null
@@ -41,7 +38,6 @@ class InfoFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentInfoBinding.inflate(inflater, container, false)
-        prefs = requireContext().getSharedPreferences("dash", Context.MODE_PRIVATE)
         return binding.root
     }
 
@@ -112,36 +108,8 @@ class InfoFragment : Fragment() {
         }
 
 
-        viewModel.onSomeSignals(
-            viewLifecycleOwner, listOf(
-                SName.displayBrightnessLev,
-                SName.solarBrightnessFactor
-            )
-        ) {
-            val solarBrightnessFactor = it[SName.solarBrightnessFactor]
-            if (solarBrightnessFactor != null) {
-                prefs.setPref(Constants.lastSolarBrightnessFactor, solarBrightnessFactor)
-            }
-            viewModel.updateBrightness()
-        }
-
-        viewModel.onSignal(viewLifecycleOwner, SName.isDarkMode) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastDarkMode)) {
-                    prefs.setPref(Constants.lastDarkMode, it)
-                    viewModel.updateTheme()
-                }
-            }
-        }
-
-        viewModel.onSignal(viewLifecycleOwner, SName.isSunUp) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastSunUp)) {
-                    prefs.setPref(Constants.lastSunUp, it)
-                    viewModel.updateTheme()
-                }
-            }
-        }
+        viewModel.startThemeListener(viewLifecycleOwner)
+        viewModel.startBrightnessListener(viewLifecycleOwner)
 
         viewModel.allSignalNames().forEach { signal ->
             signalMaxes[signal] = null

--- a/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
@@ -262,6 +262,37 @@ class PartyFragment : Fragment() {
          * Remember that it will only run when the value of the signal(s) change
          */
 
+        viewModel.onSomeSignals(
+            viewLifecycleOwner, listOf(
+                SName.displayBrightnessLev,
+                SName.solarBrightnessFactor
+            )
+        ) {
+            val solarBrightnessFactor = it[SName.solarBrightnessFactor]
+            if (solarBrightnessFactor != null) {
+                prefs.setPref(Constants.lastSolarBrightnessFactor, solarBrightnessFactor)
+            }
+            viewModel.updateBrightness()
+        }
+
+        viewModel.onSignal(viewLifecycleOwner, SName.isDarkMode) {
+            if (it != null) {
+                if (it != prefs.getPref(Constants.lastDarkMode)) {
+                    prefs.setPref(Constants.lastDarkMode, it)
+                    viewModel.updateTheme()
+                }
+            }
+        }
+
+        viewModel.onSignal(viewLifecycleOwner, SName.isSunUp) {
+            if (it != null) {
+                if (it != prefs.getPref(Constants.lastSunUp)) {
+                    prefs.setPref(Constants.lastSunUp, it)
+                    viewModel.updateTheme()
+                }
+            }
+        }
+
         viewModel.onSignal(viewLifecycleOwner, SName.keepClimateReq) {
             if (it != SVal.keepClimateParty) {
                 viewModel.switchToDashFragment()

--- a/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/PartyFragment.kt
@@ -213,36 +213,8 @@ class PartyFragment : Fragment() {
          * Remember that it will only run when the value of the signal(s) change
          */
 
-        viewModel.onSomeSignals(
-            viewLifecycleOwner, listOf(
-                SName.displayBrightnessLev,
-                SName.solarBrightnessFactor
-            )
-        ) {
-            val solarBrightnessFactor = it[SName.solarBrightnessFactor]
-            if (solarBrightnessFactor != null) {
-                prefs.setPref(Constants.lastSolarBrightnessFactor, solarBrightnessFactor)
-            }
-            viewModel.updateBrightness()
-        }
-
-        viewModel.onSignal(viewLifecycleOwner, SName.isDarkMode) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastDarkMode)) {
-                    prefs.setPref(Constants.lastDarkMode, it)
-                    viewModel.updateTheme()
-                }
-            }
-        }
-
-        viewModel.onSignal(viewLifecycleOwner, SName.isSunUp) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastSunUp)) {
-                    prefs.setPref(Constants.lastSunUp, it)
-                    viewModel.updateTheme()
-                }
-            }
-        }
+        viewModel.startThemeListener(viewLifecycleOwner)
+        viewModel.startBrightnessListener(viewLifecycleOwner)
 
         viewModel.onSignal(viewLifecycleOwner, SName.keepClimateReq) {
             if (it != SVal.keepClimateParty) {

--- a/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
@@ -32,37 +32,9 @@ class SettingsFragment() : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(requireActivity()).get(DashViewModel::class.java)
-        
-        viewModel.onSomeSignals(
-            viewLifecycleOwner, listOf(
-                SName.displayBrightnessLev,
-                SName.solarBrightnessFactor
-            )
-        ) {
-            val solarBrightnessFactor = it[SName.solarBrightnessFactor]
-            if (solarBrightnessFactor != null) {
-                prefs.setPref(Constants.lastSolarBrightnessFactor, solarBrightnessFactor)
-            }
-            viewModel.updateBrightness()
-        }
 
-        viewModel.onSignal(viewLifecycleOwner, SName.isDarkMode) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastDarkMode)) {
-                    prefs.setPref(Constants.lastDarkMode, it)
-                    viewModel.updateTheme()
-                }
-            }
-        }
-
-        viewModel.onSignal(viewLifecycleOwner, SName.isSunUp) {
-            if (it != null) {
-                if (it != prefs.getPref(Constants.lastSunUp)) {
-                    prefs.setPref(Constants.lastSunUp, it)
-                    viewModel.updateTheme()
-                }
-            }
-        }
+        viewModel.startThemeListener(viewLifecycleOwner)
+        viewModel.startBrightnessListener(viewLifecycleOwner)
 
         binding.saveSettings.setOnClickListener {
             saveSettings()

--- a/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/SettingsFragment.kt
@@ -32,6 +32,37 @@ class SettingsFragment() : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(requireActivity()).get(DashViewModel::class.java)
+        
+        viewModel.onSomeSignals(
+            viewLifecycleOwner, listOf(
+                SName.displayBrightnessLev,
+                SName.solarBrightnessFactor
+            )
+        ) {
+            val solarBrightnessFactor = it[SName.solarBrightnessFactor]
+            if (solarBrightnessFactor != null) {
+                prefs.setPref(Constants.lastSolarBrightnessFactor, solarBrightnessFactor)
+            }
+            viewModel.updateBrightness()
+        }
+
+        viewModel.onSignal(viewLifecycleOwner, SName.isDarkMode) {
+            if (it != null) {
+                if (it != prefs.getPref(Constants.lastDarkMode)) {
+                    prefs.setPref(Constants.lastDarkMode, it)
+                    viewModel.updateTheme()
+                }
+            }
+        }
+
+        viewModel.onSignal(viewLifecycleOwner, SName.isSunUp) {
+            if (it != null) {
+                if (it != prefs.getPref(Constants.lastSunUp)) {
+                    prefs.setPref(Constants.lastSunUp, it)
+                    viewModel.updateTheme()
+                }
+            }
+        }
 
         binding.saveSettings.setOnClickListener {
             saveSettings()


### PR DESCRIPTION
On first install (and any time the app is started while connected to the wrong service, such as mock service), the activity is not listening to the correct signals to update brightness and theme, causing it to not update brightness or theme when the car updates.

This is because the fullscreen activity listens to carState upon startup, and can't (easily) be changed to listen to a new carState when the service changes.

To get around this issue, we move theme and brightness listener ownership back into each fragment, as the fragments are recreated upon changing the service. To reduce code duplication, the viewModel hosts the theme and brightness listener code. The fragments trigger the activity to update via a viewmodel livedata boolean, as the theme and brightness updates are handled by the activity, not the fragments.