### PR TITLE
Fix GPU OOM crash in party mode...

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/LinearGauge.kt
+++ b/android/app/src/main/java/app/candash/cluster/LinearGauge.kt
@@ -40,15 +40,8 @@ class LinearGauge @JvmOverloads constructor(
         backgroundColor = PorterDuffColorFilter(typedValue.data, PorterDuff.Mode.SRC_ATOP)
 
         chargeColor = PorterDuffColorFilter(resources.getColor(R.color.telltale_green), PorterDuff.Mode.SRC_ATOP)
-    }
-    override fun onDraw(canvas: Canvas?) {
-        // check the value of the current theme's 'cyberMode' attribute to set 'cyber'
-        val attrSet = intArrayOf(R.attr.cyberMode)
-        val typedArray = context.obtainStyledAttributes(attrSet)
-        val newCyber = typedArray.getBoolean(0, false)
-        typedArray.recycle()
 
-        if (!cyber && newCyber) {
+        if (cyber) {
             startupAnimator = ValueAnimator.ofFloat(0f, 3f).apply {
                 duration = 2000L
                 addUpdateListener { animator ->
@@ -59,8 +52,8 @@ class LinearGauge @JvmOverloads constructor(
                 start()
             }
         }
-        cyber = newCyber
-
+    }
+    override fun onDraw(canvas: Canvas?) {
         super.onDraw(canvas)
         var startX: Float
         var stopX: Float


### PR DESCRIPTION
... and potentially in dash mode if running long enough

After hours of memory profiling, I found that rapidly calling `canvas.drawArc()` for the partial arc that overlays the circle gauge causes constant memory consumption increase on the GPU, eventually causing an OOM.

To address the issue, this PR removes all `drawArc` calls, and instead manually creates the arc paths and uses drawPath, allowing us to reuse the paths, keeping the memory in check.

This PR also cleans up some other bits of code, including an inefficiency (and bug) of checking for cybermode on every onDraw. This improves draw time but also has the side effect of fixing the cyber startup animation after the theming pr broke it.